### PR TITLE
Fix error in CHKV

### DIFF
--- a/src/core/(cc4a)code_pal_full.chkv.json
+++ b/src/core/(cc4a)code_pal_full.chkv.json
@@ -34,31 +34,31 @@
       "checkName": "/CC4A/METHOD_SIGNATURE",
       "parameters": [
         {
-          "name": "CheckPublicMethodNoInterface",
+          "name": "CheckPubMethodNoInterface",
           "value": "true"
         },
         {
-          "name": "CheckInputParameterBoolean",
+          "name": "CheckInputParamBoolean",
           "value": "true"
         },
         {
-          "name": "CheckInputParameterOptional",
+          "name": "CheckInputParamOptional",
           "value": "true"
         },
         {
-          "name": "CheckOutputParameterNumber",
+          "name": "CheckOutputParamNumber",
           "value": "true"
         },
         {
-          "name": "CheckOutputParameterType",
+          "name": "CheckOutputParamType",
           "value": "true"
         },
         {
-          "name": "CheckReturningParameterNotName",
+          "name": "CheckRetParamNotNamedResult",
           "value": "true"
         },
         {
-          "name": "CheckExportingParameterNumberN",
+          "name": "CheckExpParamNumberNotOne",
           "value": "true"
         }
       ]


### PR DESCRIPTION
Due to bug in abapGit implementation for CHKVs, only 40 characters of parameter names are transmitted. The parameters have been shortened, but somehow the corresponding fix for the CHKV wasn't committed with that.