### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Code Pal is a project that provides ATC checks to assist ABAP programmers in adh
 
 ## Requirements and Setup
 
-Install via [abapGit Eclipse plugin](https://github.com/abapGit/ADT_Frontend) on ABAP cloud systems and [abapGit for SAPGUI](https://docs.abapgit.org/guide-online-install.html) on systems with SAP_BASIS 7.58 or higher.
+Install via [abapGit Eclipse plugin](https://github.com/abapGit/ADT_Frontend) on ABAP cloud systems and [abapGit for SAPGUI](https://docs.abapgit.org/guide-online-install.html) on systems with SAP_BASIS 7.58 or higher. Since Code Pal is developed in English, logon language EN is recommended during installation.
 
-Long-term compatibility is only guaranteed for the current version of ABAP for Cloud Development. 
+Compatibility of the most recent version is only guaranteed for the current version of ABAP for Cloud Development. 
 
 ## Features
 

--- a/check_migration_list.md
+++ b/check_migration_list.md
@@ -4,35 +4,35 @@ Legend:
 
 | Legacy check | Cloud check | Quickfixes | Additional info |
 | --- | --- | --- | --- |
-| [Avoid default table keys](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/avoid-default-key.md) | migrated | yes | |
-| [Boolean input parameter](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/boolean-input-parameter.md) | migrated | no | |
+| [Avoid default table keys](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/avoid-default-key.md) | "Internal table definitions with default key" (/cc4a/avoid_default_key) | yes | |
+| [Boolean input parameter](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/boolean-input-parameter.md) | "Method Signature" (/cc4a/method_signature), parameter CheckInputParamBoolean | no | |
 | [CALL METHOD usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/call-method-usage.md) | TBM ([#1](https://github.com/SAP/code-pal-for-abap-cloud/issues/1)) | yes | |
-| [Chain declaration usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/chain-declaration-usage.md) | migrated | yes | |
-| [CHECK statement position](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/check-statement-position.md) | none | n/a | This check is a subset of the SAP-delivered Extended Program Check |
+| [Chain declaration usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/chain-declaration-usage.md) | "Chained declarations" (/cc4a/chain_declaration) | yes | |
+| [CHECK statement position](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/check-statement-position.md) | no | n/a | This check is a subset of the SAP-delivered Extended Program Check |
 | [CHECK in LOOP](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/check-in-loop.md) | TBM ([#5](https://github.com/SAP/code-pal-for-abap-cloud/issues/5)) | yes | | 
 | [COLLECT usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/collect.md) | TBM ([#6](https://github.com/SAP/code-pal-for-abap-cloud/issues/6)) | no | not relevant for ABAP Cloud (`COLLECT` is forbidden) |
-| [Combination of output parameters](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/method-output-parameter.md) | migrated | no | |
+| [Combination of output parameters](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/method-output-parameter.md) | "Method Signature" (/cc4a/method_signature), parameter CheckOutputParamType | no | |
 | [Comment position](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/comment-position.md) | TBD | no | The Cloud API for ABAP code analysis currently does not support comments |
 | [Comment type](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/comment-type.md) | TBD | no | The Cloud API for ABAP code analysis currently does not support comments |
 | [Comment usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/comment-usage.md) | TBD | no | The Cloud API for ABAP code analysis currently does not support comments |
-| [Constant interface](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/constants-interface.md) | migrated | no | |
+| [Constant interface](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/constants-interface.md) | "Constants in Interfaces" (/cc4a/check_constant_interface) | no | |
 | [Cyclomatic complexity](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/cyclomatic-complexity.md) | none | n/a | This is a subset of the SAP-delivered check "Procedural metrics" | 
 | [CX_ROOT usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/cx-root-usage.md) | none | n/a | This is a subset of the SAP-delivered Extended Program Check |
-| [Database access in unit tests](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/db-access-in-ut.md) | migrated| perhaps | The quick fix here would be rather complex: Create the statements necessary to create an SQL test double instance for the database tables accessed |
+| [Database access in unit tests](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/db-access-in-ut.md) | "Database access in unit tests" (/cc4a/db_access_in_ut) | no | 
 | [Deprecated classes](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/deprecated-classes.md) | TBD | yes | Currently this check only searches for two specific classes/interfaces, and it does not follow any explicit recommendation in the style guide|
 | [Deprecated key words](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/deprecated-key-word.md) | TBM ([#1](https://github.com/SAP/code-pal-for-abap-cloud/issues/1)) | yes | |
 | [Empty catch](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/empty-catch.md) | none | n/a | This is a subset of the SAP-delivered Extended Program Check |
 | [Empty IF branches](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/empty-if-branches.md) | none | n/a | This is a subset of the SAP-delivered Extended Program Check |
 | [Empty procedure](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/empty-procedure.md) | none | n/a | This is a subset of the SAP-delivered Extended Program Check |
-| [Assignment chaining](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/equals-sign-chaining.md) | migrated | yes | |
+| [Assignment chaining](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/equals-sign-chaining.md) | "Assignment Chaining" (/cc4a/equals_sign_chaining) | yes | |
 | [External call in unit test](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/external-call-in-ut.md) | none | n/a | Does not correspond to any section in the style guide |
 | [FORM usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/form-routine.md) | TBM ([#10](https://github.com/SAP/code-pal-for-abap-cloud/issues/10)) | no | not relevant for ABAP Cloud (`PERFORM` is forbidden) |
 | [FUNCTION usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/function-routine.md) | TBM ([#10](https://github.com/SAP/code-pal-for-abap-cloud/issues/10)) | no | not relevant for ABAP Cloud (non-RFC function module cannot be used anyway) |
 | [Magic numbers](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/magic-number.md) | none | n/a | This is a subset of the SAP-delivered Extended Program Check |
-| [Message easy to find](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/message-easy-to-find.md) | TBM ([#11](https://github.com/SAP/code-pal-for-abap-cloud/issues/11)) | perhaps | |
+| [Message easy to find](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/message-easy-to-find.md) | TBM ([#11](https://github.com/SAP/code-pal-for-abap-cloud/issues/11)) | perhaps | currently blocked because there is no released remote API to find out whether a message class exists |
 | [Message translation](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/message-translation.md) | none | n/a | This is a subset of the SAP-delivered Extended Program Check |
 | [Boolean method names](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/method-return-bool.md) | TBD | no | While this seems to be "in the spirit" of Clean ABAP, it does not actually correspond to any section in the style guide |
-| [Missing interface](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/interface-in-class.md) | migrated | no | Creating a new global interface is not currently possible via the quick fix API |
+| [Missing interface](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/interface-in-class.md) | "Method Signature" (/cc4a/method_signature), parameter CheckPubMethodNoInterface | no | Creating a new global interface is not currently possible via the quick fix API |
 | [Nesting depth](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/maximum-nesting-depth.md) | none | n/a | Subset of SAP-delivered "Procedural metrics" check | 
 | [Classic exception usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/non-class-exception.md) | none | n/a | Subset of SAP-delivered Extended Program Check |
 | [Number of attributes](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/number-attributes.md) | none | n/a | Subset of SAP-delivered "Object-oriented metrics" check | 
@@ -41,21 +41,21 @@ Legend:
 | [Number of interfaces](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/number-interfaces.md) | none | n/a | Subset of SAP-delivered "Object-oriented metrics" check | 
 | [Number of methods](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/number-methods.md) | none | n/a | Subset of SAP-delivered "Object-oriented metrics" check | 
 | [Number of public attributes](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/number-public-attributes.md) | none | n/a | Subset of SAP-delivered "Object-oriented metrics" check | 
-| [Number of output parameters](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/number-output-parameter.md) | migrated | no | Should be merged with "Combination of output parameters" check |
+| [Number of output parameters](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/number-output-parameter.md) | "Method Signature" (/cc4a/method_signature), parameter CheckOutputParamNumber | no | Should be merged with "Combination of output parameters" check |
 | [Prefer CASE to ELSEIF](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/prefer-case-to-elseif.md) | TBM ([#12](https://github.com/SAP/code-pal-for-abap-cloud/issues/12)) | yes | |
-| [Prefer RETURNING to EXPORTING](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/prefer-returning-to-exporting.md) | migrated | yes | |
-| [Prefer IS NOT to NOT IS](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/prefer-is-not-to-not-is.md) | migrated | yes | |
+| [Prefer RETURNING to EXPORTING](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/prefer-returning-to-exporting.md) | "Method Signature" (/cc4a/method_signature) | yes | |
+| [Prefer IS NOT to NOT IS](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/prefer-is-not-to-not-is.md) | ""NOT IS" in logical expressions" (/cc4a/prefer_is_not ) | yes | |
 | [Prefer line_* over READ TABLE/LOOP AT ... WHERE](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/prefer-line-exists.md) | TBM ([#1](https://github.com/SAP/code-pal-for-abap-cloud/issues/1)) | yes | Consider merging into "deprecated keywords" |
 | [Prefer NEW to CREATE OBJECT](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/prefer-new-to-create-object.md) | TBM ([#1](https://github.com/SAP/code-pal-for-abap-cloud/issues/1)) | yes | Consider merging into "deprecated keywords" |
 | [Prefer pragmas to pseudo comments](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/prefer-pragmas-to-pseudo-comments.md) | TBD | n/a | The Cloud API for ABAP code analysis currently does not support pragmas |
 | [Pseudo comment usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/pseudo-comment-usage.md) | TBD | no | The ATC already offers the option to not consider pseudo comments, so the stated purpose of this check doesn't need a check. However, one could see a use case for actually *finding* all locations where pseudo comments are used. | 
 | [Omit optional EXPORTING](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/omit-optional-exporting.md) | TBM ([#1](https://github.com/SAP/code-pal-for-abap-cloud/issues/1)) | yes | | 
-| [Optional parameters](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/optional-parameters.md) | migrated | no | |
+| [Optional parameters](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/optional-parameters.md) | "Method Signature" (/cc4a/method_signature), parameter CheckInputParamOptional | no | |
 | [READ TABLE into field symbols](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/sub-assign-read-table.md) | TBD | no | The Extended Program Check has a similar but not identical check |
 | [RECEIVING usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/receiving-usage.md) | TBM ([#1](https://github.com/SAP/code-pal-for-abap-cloud/issues/1)) | yes | |
-| [Returning name](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/returning-name.md) | migrated | yes | |
+| [Returning name](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/returning-name.md) | "Method Signature" (/cc4a/method_signature), parameter CheckRetParamNotNamedResult | yes | |
 | [Scope of variable](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/scope-of-variable.md) | TBM ([#14](https://github.com/SAP/code-pal-for-abap-cloud/issues/14))| yes ||
-| [Self-reference](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/self-reference.md) | migrated | yes | |
-| [TEST-SEAM usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/test-seam-usage.md) | migrated | yes | |
+| [Self-reference](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/self-reference.md) | "Find unnecessary self-references" (/cc4a/avoid_self_reference) | yes | |
+| [TEST-SEAM usage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/test-seam-usage.md) | "Usage of TEST-SEAM" (/cc4a/avoid_test_seam) | yes | |
 | [Text assembly](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/text-assembly.md) | TBM ([#1](https://github.com/SAP/code-pal-for-abap-cloud/issues/1)) | yes | |
 | [Unit test coverage](https://github.com/SAP/code-pal-for-abap/blob/master/docs/checks/unit-test-coverages.md) | none | n/a | There is no Cloud API for executing unit tests (yet) and since unit tests are often executed during an ATC run anyway, coverage should be measured in that step and not by an additional ATC check - executing unit tests twice may lead to performance degradation. |

--- a/src/checks/#cc4a#avoid_test_seam.clas.abap
+++ b/src/checks/#cc4a#avoid_test_seam.clas.abap
@@ -27,7 +27,7 @@ class /cc4a/avoid_test_seam implementation.
   method if_ci_atc_check~get_meta_data.
     meta_data = /cc4a/check_meta_data=>create(
       value #( checked_types = /cc4a/check_meta_data=>checked_types-abap_programs
-          description = 'Find usage of TEST-SEAM'(des)
+          description = 'Usage of TEST-SEAM'(des)
           remote_enablement = /cc4a/check_meta_data=>remote_enablement-unconditional
           finding_codes = value #(
             ( code = finding_code pseudo_comment = pseudo_comment text = 'Usage of TEST-SEAM'(uot) ) )

--- a/src/checks/#cc4a#db_access_in_ut.clas.abap
+++ b/src/checks/#cc4a#db_access_in_ut.clas.abap
@@ -74,10 +74,10 @@ class /cc4a/db_access_in_ut implementation.
   method if_ci_atc_check~get_meta_data.
     meta_data = /cc4a/check_meta_data=>create(
       value #( checked_types = /cc4a/check_meta_data=>checked_types-abap_programs
-        description = 'Avoid data base access in unit-tests'(des)
+        description = 'Database access in unit tests'(des)
         remote_enablement = /cc4a/check_meta_data=>remote_enablement-unconditional
         finding_codes = value #(
-          ( code = finding_code pseudo_comment = pseudo_comment text = 'Database access in unit-test'(dau) ) )
+          ( code = finding_code pseudo_comment = pseudo_comment text = 'Database access in unit test'(dau) ) )
         ) ).
   endmethod.
 

--- a/src/checks/(cc4a)assignment_chaining.chko.json
+++ b/src/checks/(cc4a)assignment_chaining.chko.json
@@ -6,5 +6,6 @@
     "abapLanguageVersion": "cloudDevelopment"
   },
   "category": "/CC4A/CODE_PAL",
-  "implementingClass": "/CC4A/EQUALS_SIGN_CHAINING"
+  "implementingClass": "/CC4A/EQUALS_SIGN_CHAINING",
+  "checkType": "remoteEnabled"
 }

--- a/src/checks/(cc4a)avoid_db_access_in_aunit.chko.json
+++ b/src/checks/(cc4a)avoid_db_access_in_aunit.chko.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "1",
   "header": {
-    "description": "Avoid DB access in unit-tests",
+    "description": "Database access in unit-tests",
     "originalLanguage": "en",
     "abapLanguageVersion": "cloudDevelopment"
   },

--- a/src/checks/(cc4a)avoid_default_key.chko.json
+++ b/src/checks/(cc4a)avoid_default_key.chko.json
@@ -6,5 +6,6 @@
     "abapLanguageVersion": "cloudDevelopment"
   },
   "category": "/CC4A/CODE_PAL",
-  "implementingClass": "/CC4A/AVOID_DEFAULT_KEY"
+  "implementingClass": "/CC4A/AVOID_DEFAULT_KEY",
+  "checkType": "remoteEnabled"
 }

--- a/src/checks/(cc4a)avoid_self_reference.chko.json
+++ b/src/checks/(cc4a)avoid_self_reference.chko.json
@@ -6,5 +6,6 @@
     "abapLanguageVersion": "cloudDevelopment"
   },
   "category": "/CC4A/CODE_PAL",
-  "implementingClass": "/CC4A/AVOID_SELF_REFERENCE"
+  "implementingClass": "/CC4A/AVOID_SELF_REFERENCE",
+  "checkType": "remoteEnabled"
 }

--- a/src/checks/(cc4a)avoid_test_seam.chko.json
+++ b/src/checks/(cc4a)avoid_test_seam.chko.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": "1",
   "header": {
-    "description": "Avoid using TEST-SEAM",
+    "description": "Usage of TEST-SEAM",
     "originalLanguage": "en",
     "abapLanguageVersion": "cloudDevelopment"
   },

--- a/src/checks/(cc4a)chain_declarations.chko.json
+++ b/src/checks/(cc4a)chain_declarations.chko.json
@@ -6,5 +6,6 @@
     "abapLanguageVersion": "cloudDevelopment"
   },
   "category": "/CC4A/CODE_PAL",
-  "implementingClass": "/CC4A/CHAIN_DECLARATION"
+  "implementingClass": "/CC4A/CHAIN_DECLARATION",
+  "checkType": "remoteEnabled"
 }

--- a/src/checks/(cc4a)constants_interface.chko.json
+++ b/src/checks/(cc4a)constants_interface.chko.json
@@ -6,5 +6,6 @@
     "abapLanguageVersion": "cloudDevelopment"
   },
   "category": "/CC4A/CODE_PAL",
-  "implementingClass": "/CC4A/CHECK_CONSTANT_INTERFACE"
+  "implementingClass": "/CC4A/CHECK_CONSTANT_INTERFACE",
+  "checkType": "remoteEnabled"
 }

--- a/src/checks/(cc4a)method_signature.chko.json
+++ b/src/checks/(cc4a)method_signature.chko.json
@@ -37,5 +37,5 @@
       "name": "CheckExpParamNumberNotOne",
       "description": "Check number of exporting parameter more than 1"
     }
-  ],
+  ]
 }

--- a/src/checks/(cc4a)method_signature.chko.json
+++ b/src/checks/(cc4a)method_signature.chko.json
@@ -37,5 +37,5 @@
       "name": "CheckExpParamNumberNotOne",
       "description": "Check number of exporting parameter more than 1"
     }
-  ]
+  ],
 }

--- a/src/checks/(cc4a)prefer_is_not.chko.json
+++ b/src/checks/(cc4a)prefer_is_not.chko.json
@@ -6,5 +6,6 @@
     "abapLanguageVersion": "cloudDevelopment"
   },
   "category": "/CC4A/CODE_PAL",
-  "implementingClass": "/CC4A/PREFER_IS_NOT"
+  "implementingClass": "/CC4A/PREFER_IS_NOT",
+  "checkType": "remoteEnabled"
 }


### PR DESCRIPTION
 - If the logon language when pulling via abapGit is not EN, you get a bunch of errors/warning that can be avoided by logging on with EN
 - More consistency in check titles
 - Add new check titles to the migration list