### PR TITLE
Add CI_ to pseudo comments

### DIFF
--- a/src/checks/#cc4a#avoid_default_key.clas.abap
+++ b/src/checks/#cc4a#avoid_default_key.clas.abap
@@ -6,12 +6,16 @@ class /cc4a/avoid_default_key definition
   public section.
     interfaces if_ci_atc_check.
 
-    constants finding_code type if_ci_atc_check=>ty_finding_code value 'DEFAULTKEY'.
-
+    constants:
+      begin of finding_codes,
+        default_key type if_ci_atc_check=>ty_finding_code value 'DEFAULTKEY',
+      end of finding_codes.
     constants:
       begin of quickfix_codes,
-        empty_key      type cl_ci_atc_quickfixes=>ty_quickfix_code value 'EMPTYKEY',
+        empty_key type cl_ci_atc_quickfixes=>ty_quickfix_code value 'EMPTYKEY',
       end of quickfix_codes.
+
+    methods constructor.
 
   protected section.
   private section.
@@ -19,6 +23,7 @@ class /cc4a/avoid_default_key definition
 
     data code_provider     type ref to if_ci_atc_source_code_provider.
     data assistant_factory type ref to cl_ci_atc_assistant_factory.
+    data meta_data type ref to /cc4a/if_check_meta_data.
 
     methods analyze_procedure
       importing procedure       type if_ci_atc_source_code_provider=>ty_procedure
@@ -51,10 +56,12 @@ CLASS /CC4A/AVOID_DEFAULT_KEY IMPLEMENTATION.
             value #( procedure_id = procedure-id statements = value #( from = sy-tabix to = sy-tabix ) ) )
           code = replace_empty_key( statement = <statement> key_word_position = found_at_position ) ).
         insert value #(
-          code = finding_code
+          code = finding_codes-default_key
           location = code_provider->get_statement_location( <statement> )
           checksum = code_provider->get_statement_checksum( <statement> )
-          has_pseudo_comment = xsdbool( line_exists( <statement>-pseudo_comments[ table_line = pseudo_comment ] ) )
+          has_pseudo_comment = meta_data->has_valid_pseudo_comment(
+            statement = <statement>
+            finding_code = finding_codes-default_key )
           details = assistant_factory->create_finding_details( )->attach_quickfixes( available_quickfixes )
         ) into table findings.
       endif.
@@ -64,15 +71,19 @@ CLASS /CC4A/AVOID_DEFAULT_KEY IMPLEMENTATION.
 
 
   method if_ci_atc_check~get_meta_data.
+    meta_data = me->meta_data.
+  endmethod.
+
+  method constructor.
     meta_data = /cc4a/check_meta_data=>create(
       value #( checked_types = /cc4a/check_meta_data=>checked_types-abap_programs
           description = 'Avoid default keys'(des)
           remote_enablement = /cc4a/check_meta_data=>remote_enablement-unconditional
           finding_codes = value #(
-          ( code = finding_code pseudo_comment = pseudo_comment text = 'Usage of default table key'(dtk) ) )
-          quickfix_codes = value #(
-          ( code = quickfix_codes-empty_key short_text = 'Replace WITH DEFAULT KEY with WITH EMPTY KEY'(qek) ) )
-        ) ).
+          ( code = finding_codes-default_key
+            pseudo_comment = pseudo_comment text = 'Usage of default table key'(dtk) ) )
+            quickfix_codes = value #(
+            ( code = quickfix_codes-empty_key short_text = 'Replace WITH DEFAULT KEY with WITH EMPTY KEY'(qek) ) ) ) ).
   endmethod.
 
 

--- a/src/checks/#cc4a#avoid_default_key.clas.testclasses.abap
+++ b/src/checks/#cc4a#avoid_default_key.clas.testclasses.abap
@@ -55,46 +55,46 @@ class test implementation.
       check             = new /cc4a/avoid_default_key( )
       object            = value #( type = 'CLAS' name = test_class )
       expected_findings = value #(
-        ( code = /cc4a/avoid_default_key=>finding_code
+        ( code = /cc4a/avoid_default_key=>finding_codes-default_key
           location = psuedo_comment_1
           quickfixes = value #( (
             quickfix_code = /cc4a/avoid_default_key=>quickfix_codes-empty_key
             location = psuedo_comment_1
             code = value #(
             ( `CLASS-DATA GHI TYPE TABLE OF TY_STRUCT WITH EMPTY KEY .` ) ) ) ) )
-        ( code = /cc4a/avoid_default_key=>finding_code
+        ( code = /cc4a/avoid_default_key=>finding_codes-default_key
           location = psuedo_comment_2
           quickfixes = value #( (
             quickfix_code = /cc4a/avoid_default_key=>quickfix_codes-empty_key
             location = psuedo_comment_2
             code = value #(
             ( `DATA STU TYPE TABLE OF TY_STRUCT WITH EMPTY KEY .` ) ) ) ) )
-        ( code = /cc4a/avoid_default_key=>finding_code
+        ( code = /cc4a/avoid_default_key=>finding_codes-default_key
           location = psuedo_comment_3 )
-        ( code = /cc4a/avoid_default_key=>finding_code
+        ( code = /cc4a/avoid_default_key=>finding_codes-default_key
           location = finding_1
           quickfixes = value #( (
             quickfix_code = /cc4a/avoid_default_key=>quickfix_codes-empty_key
             location = finding_1
             code = value #(
             ( `CLASS-DATA ABC TYPE TABLE OF TY_STRUCT WITH EMPTY KEY .` ) ) ) ) )
-        ( code = /cc4a/avoid_default_key=>finding_code
+        ( code = /cc4a/avoid_default_key=>finding_codes-default_key
           location = finding_2
           quickfixes = value #( (
             quickfix_code = /cc4a/avoid_default_key=>quickfix_codes-empty_key
             location = finding_2
             code = value #(
             ( `DATA STU TYPE TABLE OF TY_STRUCT WITH EMPTY KEY .` ) ) ) ) )
-        ( code = /cc4a/avoid_default_key=>finding_code
+        ( code = /cc4a/avoid_default_key=>finding_codes-default_key
           location = finding_3 )
-        ( code = /cc4a/avoid_default_key=>finding_code
+        ( code = /cc4a/avoid_default_key=>finding_codes-default_key
           location = static_finding_1
           quickfixes = value #( (
             quickfix_code = /cc4a/avoid_default_key=>quickfix_codes-empty_key
             location = static_finding_1
             code = value #(
             ( `STATICS MEMO TYPE STANDARD TABLE OF STRING WITH EMPTY KEY .` ) ) ) ) )
-        ( code = /cc4a/avoid_default_key=>finding_code
+        ( code = /cc4a/avoid_default_key=>finding_codes-default_key
           location = static_finding_2
           quickfixes = value #( (
             quickfix_code = /cc4a/avoid_default_key=>quickfix_codes-empty_key

--- a/src/checks/#cc4a#avoid_self_reference.clas.testclasses.abap
+++ b/src/checks/#cc4a#avoid_self_reference.clas.testclasses.abap
@@ -166,259 +166,259 @@ class test implementation.
           check             = new /cc4a/avoid_self_reference( )
           object            = value #( type = 'CLASS' name = test_class )
           expected_findings = value #(
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = with_pseudo_comment_1
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = with_pseudo_comment_1
                 code = value #(
                 ( `NUMBER1 = ME->NUMBER1 + NUMBER2 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = with_pseudo_comment_2
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = with_pseudo_comment_2
                 code = value #(
                 ( `NUMBER5 = NUMBER2 + NUMBER3 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = with_pseudo_comment_3
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = with_pseudo_comment_3
                 code = value #(
                 ( `NUMBER2 = NUMBER4 + NUMBER5 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = with_pseudo_comment_4
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = with_pseudo_comment_4
                 code = value #(
                 ( `STRING1 = ME->STRING1 + STRING2 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = with_pseudo_comment_5
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = with_pseudo_comment_5
                 code = value #(
                 ( `STRING5 = STRING2 + STRING3 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = with_pseudo_comment_6
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = with_pseudo_comment_6
                 code = value #(
                 ( `STRING2 = STRING4 + STRING5 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = with_pseudo_comment_7
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = with_pseudo_comment_7
                 code = value #(
                 ( `WITHOUT_PSEUDO_COMMENTS( NUMBER = NUMBER3 STRING = STRING3 ) .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = with_pseudo_comment_8
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = with_pseudo_comment_8
                 code = value #(
                 ( `WITH_PSEUDO_COMMENTS( NUMBER = ME->NUMBER1 STRING = STRING3 ) .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = with_pseudo_comment_9
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = with_pseudo_comment_9
                 code = value #(
                 ( `WITH_PSEUDO_COMMENTS( NUMBER = NUMBER4 STRING = STRING4 ) .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = with_pseudo_comment_10
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = with_pseudo_comment_10
                 code = value #(
                 ( `WITH_PSEUDO_COMMENTS( NUMBER = NUMBER2 STRING = STRING5 ) .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = without_pseudo_comment_1
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = without_pseudo_comment_1
                 code = value #(
                 ( `NUMBER1 = ME->NUMBER1 + NUMBER2 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = without_pseudo_comment_2
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = without_pseudo_comment_2
                 code = value #(
                 ( `NUMBER5 = NUMBER2 + NUMBER3 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = without_pseudo_comment_3
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = without_pseudo_comment_3
                 code = value #(
                 ( `NUMBER2 = NUMBER4 + NUMBER5 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = without_pseudo_comment_4
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = without_pseudo_comment_4
                 code = value #(
                 ( `STRING1 = ME->STRING1 + STRING2 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = without_pseudo_comment_5
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = without_pseudo_comment_5
                 code = value #(
                 ( `STRING5 = STRING2 + STRING3 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = without_pseudo_comment_6
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = without_pseudo_comment_6
                 code = value #(
                 ( `STRING2 = STRING4 + STRING5 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = without_pseudo_comment_7
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = without_pseudo_comment_7
                 code = value #(
                 ( `WITHOUT_PSEUDO_COMMENTS( NUMBER = NUMBER3 STRING = STRING3 ) .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = without_pseudo_comment_8
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = without_pseudo_comment_8
                 code = value #(
                 ( `WITH_PSEUDO_COMMENTS( NUMBER = ME->NUMBER1 STRING = STRING3 ) .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = without_pseudo_comment_9
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = without_pseudo_comment_9
                 code = value #(
                 ( `WITH_PSEUDO_COMMENTS( NUMBER = NUMBER4 STRING = STRING4 ) .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = without_pseudo_comment_10
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = without_pseudo_comment_10
                 code = value #(
                 ( `WITH_PSEUDO_COMMENTS( NUMBER = NUMBER2 STRING = STRING5 ) .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = define_and_write_finding_1
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = define_and_write_finding_1
                 code = value #(
                 ( `DATA(STRING) = STRING1 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = define_and_write_finding_2
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = define_and_write_finding_2
                 code = value #(
                 ( `FINAL(SECOND_STRING) = STRING2 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = define_and_write_finding_3
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = define_and_write_finding_3
                 code = value #(
                 ( `FINAL(STRING) = STRING2 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = define_and_write_finding_4
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = define_and_write_finding_4
                 code = value #(
                 ( `DATA(NUMBER) = NUMBER1 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = structure_finding_1
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = structure_finding_1
                 code = value #(
                 ( `DATA(STRUCTURE) = STRUCT-COMP .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = structure_finding_2
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = structure_finding_2
                 code = value #(
                 ( `STRUCTURE = STRUCT-COMP .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = local_finding_1
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = local_finding_1
                 code = value #(
                 ( `ATT4 = 7 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = local_finding_2
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = local_finding_2
                 code = value #(
                 ( `ATT1 = 2 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = local_finding_3
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = local_finding_3
                 code = value #(
                 ( `ATT3 = 'Hugo' .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = local_finding_4
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = local_finding_4
                 code = value #(
                 ( `ATT5 = 5 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = local_finding_5
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = local_finding_5
                 code = value #(
                 ( `ATT1 = 2 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = test_class_finding_1
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = test_class_finding_1
                 code = value #(
                 ( `ATT4 = 7 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = test_class_finding_2
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = test_class_finding_2
                 code = value #(
                 ( `ATT1 = 2 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = test_class_finding_3
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = test_class_finding_3
                 code = value #(
                 ( `ATT3 = 'Hugo' .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = test_class_finding_4
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = test_class_finding_4
                 code = value #(
                 ( `ATT4 = 7 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = test_class_finding_5
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
                 location = test_class_finding_5
                 code = value #(
                 ( `ATT4 = 5 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_code
+            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = test_class_finding_6
                 quickfixes = value #( (
                 quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference

--- a/src/checks/#cc4a#avoid_test_seam.clas.testclasses.abap
+++ b/src/checks/#cc4a#avoid_test_seam.clas.testclasses.abap
@@ -45,18 +45,13 @@ class test implementation.
     cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
               check             = new /cc4a/avoid_test_seam( )
               object            = value #( type = 'CLASS' name = test_class )
-              expected_findings = value #( ( code = /cc4a/avoid_test_seam=>finding_code
-                                         location = without_pseudo_comment_1 )
-                                         ( code = /cc4a/avoid_test_seam=>finding_code
-                                         location = without_pseudo_comment_2 )
-                                         ( code = /cc4a/avoid_test_seam=>finding_code
-                                         location = without_pseudo_comment_3 )
-                                         ( code = /cc4a/avoid_test_seam=>finding_code
-                                         location = with_pseudo_comment_1 )
-                                         ( code = /cc4a/avoid_test_seam=>finding_code
-                                         location = with_pseudo_comment_2 )
-                                         ( code = /cc4a/avoid_test_seam=>finding_code
-                                         location = with_pseudo_comment_3 ) )
+              expected_findings = value #( code = /cc4a/avoid_test_seam=>finding_codes-test_seam
+                                         ( location = without_pseudo_comment_1 )
+                                         ( location = without_pseudo_comment_2 )
+                                         ( location = without_pseudo_comment_3 )
+                                         ( location = with_pseudo_comment_1 )
+                                         ( location = with_pseudo_comment_2 )
+                                         ( location = with_pseudo_comment_3 ) )
               asserter_config   = value #( quickfixes = abap_false ) ).
   endmethod.
 

--- a/src/checks/#cc4a#chain_declaration.clas.testclasses.abap
+++ b/src/checks/#cc4a#chain_declaration.clas.testclasses.abap
@@ -131,66 +131,59 @@ class test implementation.
               check             = new /cc4a/chain_declaration( )
               object            = value #( type = 'CLAS' name = test_class )
               expected_findings = value #(
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = section_finding_1
+                code =  /cc4a/chain_declaration=>finding_codes-chain_declaration
+                ( location = section_finding_1
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_sf_1
                     code = value #(
                     ( `CONSTANTS Q TYPE I VALUE 0 .` )
                     ( `CONSTANTS W TYPE I VALUE 0 .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = section_finding_2
+                ( location = section_finding_2
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_sf_2
                     code = value #(
                     ( `CLASS-DATA O TYPE I .` )
                     ( `CLASS-DATA P TYPE I .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = section_finding_3
+                ( location = section_finding_3
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_sf_3
                     code = value #(
                     ( `DATA ASD TYPE D .` )
                     ( `DATA FDG TYPE D .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = static_finding_1
+                ( location = static_finding_1
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_stf_1
                     code = value #(
                     ( `STATICS THIRD TYPE I .` )
                     ( `STATICS FOURTH TYPE I .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = static_finding_2
+                ( location = static_finding_2
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_stf_2
                     code = value #(
                     ( `STATICS DSGZ TYPE I .` )
                     ( `STATICS ASG TYPE I .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = without_pseudo_comment_1
+                ( location = without_pseudo_comment_1
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_wopc_1
                     code = value #(
                     ( `DATA Z TYPE I . DATA K TYPE I . DATA B TYPE I .` )
                     ( `DATA D TYPE I .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = without_pseudo_comment_2
+                ( location = without_pseudo_comment_2
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_wopc_2
                     code = value #(
                     ( `TYPES TY_TYPE2 TYPE TY_TYPES .` )
                     ( `TYPES TY_TYPE3 TYPE TY_TYPES .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = without_pseudo_comment_3
+                ( location = without_pseudo_comment_3
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_wopc_3
                     code = value #(
                     ( `TYPES TY_EXEMPTIONS TYPE STANDARD TABLE OF STRING WITH EMPTY KEY .` )
@@ -216,10 +209,9 @@ class test implementation.
                     ( `CHKMSGID TYPE XSTRING ,` )
                     ( `RANGE TYPE RANGE OF XSTRING ,` )
                     ( `END OF CURRENT_CHKMSGID_T .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = without_pseudo_comment_4
+                ( location = without_pseudo_comment_4
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_wopc_4
                     code = value #(
                     ( `CONSTANTS:` )
@@ -230,28 +222,25 @@ class test implementation.
                     ( `WORKLIST_ID TYPE ty_object_with_exemptions-key-obj_name VALUE 'WORKLIST_ID' ,` )
                     ( `END OF C_CFG_PARAM2 .` )
                     ( `CONSTANTS C_MODULE_ID2 TYPE xstring VALUE '005056A7004E1EE682F6E8FEE661C090' .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = with_pseudo_comment_1
+                ( location = with_pseudo_comment_1
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_wpc_1
                     code = value #(
                     ( `DATA Q TYPE I .` )
                     ( `DATA W TYPE I .` )
                     ( `DATA E TYPE I .` )
                     ( `DATA R TYPE I .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = with_pseudo_comment_2
+                ( location = with_pseudo_comment_2
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_wpc_2
                     code = value #(
                     ( `TYPES TY_TYPE10 TYPE TY_TYPES .` )
                     ( `TYPES TY_TYPE13 TYPE TY_TYPES .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = with_pseudo_comment_3
+                ( location = with_pseudo_comment_3
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_wpc_3
                     code = value #(
                     ( `CONSTANTS:` )
@@ -270,10 +259,9 @@ class test implementation.
                     ( `OBJECT_CONTEXT TYPE c length 40 VALUE 'OBJCTX' ,` )
                     ( `DYNTEST_OBJECT TYPE c length 40 VALUE 'DYNTEST_OBJECT' ,` )
                     ( `END OF C_SET_PARAM .` ) ) ) ) )
-                ( code = /cc4a/chain_declaration=>finding_code
-                    location = with_pseudo_comment_4
+                ( location = with_pseudo_comment_4
                     quickfixes = value #( (
-                    quickfix_code = /cc4a/chain_declaration=>quickfix_code
+                    quickfix_code = /cc4a/chain_declaration=>quickfix_codes-resolve_chain
                     location = quickfix_location_wpc_4
                     code = value #(
                     ( `TYPES: TY_EXEMPTIONS TYPE STANDARD TABLE OF STRING WITH EMPTY KEY .` )

--- a/src/checks/#cc4a#check_constant_interface.clas.abap
+++ b/src/checks/#cc4a#check_constant_interface.clas.abap
@@ -7,41 +7,42 @@ class /cc4a/check_constant_interface definition
     interfaces if_ci_atc_check.
 
     constants:
-      begin of message_codes,
+      begin of finding_codes,
         cons_intf type if_ci_atc_check=>ty_finding_code value 'CONS_INTF',
-      end of   message_codes.
+      end of   finding_codes.
     constants:
       begin of pseudo_comments,
         cons_intf type string value 'CONS_INTF',
       end of   pseudo_comments.
+    methods constructor.
 
   protected section.
   private section.
-    data code_provider     type ref to if_ci_atc_source_code_provider.
+    data code_provider type ref to if_ci_atc_source_code_provider.
+    data meta_data type ref to /cc4a/if_check_meta_data.
+ENDCLASS.
 
-endclass.
 
 
-
-class /cc4a/check_constant_interface implementation.
+CLASS /CC4A/CHECK_CONSTANT_INTERFACE IMPLEMENTATION.
 
 
   method if_ci_atc_check~get_meta_data.
+    meta_data = me->meta_data.
+  endmethod.
 
+  method constructor.
     meta_data = /cc4a/check_meta_data=>create( value #(
       checked_types = /cc4a/check_meta_data=>checked_types-abap_programs
       description = 'Constants in Interfaces'(des)
       finding_codes = value #(
-        ( code = message_codes-cons_intf
+        ( code = finding_codes-cons_intf
           pseudo_comment = pseudo_comments-cons_intf
           text = 'Interface contains only constants'(mc1) ) )
       remote_enablement = /cc4a/check_meta_data=>remote_enablement-unconditional ) ).
-
   endmethod.
 
-
   method if_ci_atc_check~run.
-
     code_provider = data_provider->get_code_provider( ).
     data(procedures) = code_provider->get_procedures( code_provider->object_to_comp_unit( object = object ) ).
 
@@ -65,11 +66,12 @@ class /cc4a/check_constant_interface implementation.
           when 'ENDINTERFACE'.
             if has_something_else = abap_false and at_least_one_constant = abap_true.
               insert value #(
-                code = message_codes-cons_intf
+                code = finding_codes-cons_intf
                 location = code_provider->get_statement_location( intf_decl_statement )
                 checksum = code_provider->get_statement_checksum( intf_decl_statement )
-                has_pseudo_comment = xsdbool(
-                  line_exists( intf_decl_statement-pseudo_comments[ table_line = pseudo_comments-cons_intf ] ) )
+                has_pseudo_comment = meta_data->has_valid_pseudo_comment(
+                  statement = intf_decl_statement
+                  finding_code = finding_codes-cons_intf )
               ) into table findings.
             else.
               has_something_else = abap_false.
@@ -92,7 +94,6 @@ class /cc4a/check_constant_interface implementation.
       endloop.
 
     endloop.
-
   endmethod.
 
 
@@ -104,4 +105,4 @@ class /cc4a/check_constant_interface implementation.
   method if_ci_atc_check~verify_prerequisites.
 
   endmethod.
-endclass.
+ENDCLASS.

--- a/src/checks/#cc4a#check_constant_interface.clas.testclasses.abap
+++ b/src/checks/#cc4a#check_constant_interface.clas.testclasses.abap
@@ -33,7 +33,7 @@ class ltcl_ implementation.
                                    type = co_test_object-object_type_2 )
       asserter_config   = value #( quickfixes                 = abap_false
                                    remove_findings_with_pcoms = abap_true )
-      expected_findings = value #( ( code       = /cc4a/check_constant_interface=>message_codes-cons_intf
+      expected_findings = value #( ( code       = /cc4a/check_constant_interface=>finding_codes-cons_intf
                                      location   = finding_1_loc ) ) ).
 
   endmethod.
@@ -56,9 +56,9 @@ class ltcl_ implementation.
                                    type = co_test_object-object_type_1 )
       asserter_config   = value #( quickfixes                 = abap_false
                                    remove_findings_with_pcoms = abap_true )
-      expected_findings = value #( ( code       = /cc4a/check_constant_interface=>message_codes-cons_intf
+      expected_findings = value #( ( code       = /cc4a/check_constant_interface=>finding_codes-cons_intf
                                      location   = finding_1_loc )
-                                   ( code       = /cc4a/check_constant_interface=>message_codes-cons_intf
+                                   ( code       = /cc4a/check_constant_interface=>finding_codes-cons_intf
                                      location   = finding_2_loc ) ) ).
 
   endmethod.

--- a/src/checks/#cc4a#equals_sign_chaining.clas.testclasses.abap
+++ b/src/checks/#cc4a#equals_sign_chaining.clas.testclasses.abap
@@ -69,13 +69,13 @@ class ltcl_test implementation.
                                    type = co_test_object-object_type )
       asserter_config   = value #( quickfixes                 = abap_false
                                    remove_findings_with_pcoms = abap_true )
-      expected_findings = value #( ( code       = /cc4a/equals_sign_chaining=>message_codes-eqals_sign_chaining
+      expected_findings = value #( ( code       = /cc4a/equals_sign_chaining=>finding_codes-equals_sign_chaining
                                      location   = finding_1_loc
                                      quickfixes = qf1_finding_1 )
-                                   ( code       = /cc4a/equals_sign_chaining=>message_codes-eqals_sign_chaining
+                                   ( code       = /cc4a/equals_sign_chaining=>finding_codes-equals_sign_chaining
                                      location   = finding_2_loc
                                      quickfixes = qf1_finding_2 )
-                                   ( code       = /cc4a/equals_sign_chaining=>message_codes-eqals_sign_chaining
+                                   ( code       = /cc4a/equals_sign_chaining=>finding_codes-equals_sign_chaining
                                      location   = finding_4_loc
                                      quickfixes = qf1_finding_4 ) ) ).
 

--- a/src/checks/#cc4a#prefer_is_not.clas.testclasses.abap
+++ b/src/checks/#cc4a#prefer_is_not.clas.testclasses.abap
@@ -180,273 +180,235 @@ class test implementation.
     cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
       check             = new /cc4a/prefer_is_not( )
       object            = value #( type = 'CLAS' name = test_class )
-      expected_findings = value #( ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_1
+      expected_findings = value #( code = /cc4a/prefer_is_not=>finding_codes-misplaced_not
+                                   ( location = without_brackets_1
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        code = value #(
                                        ( `ASSERT GETINT( ) <> GETBOOL( ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_2
+                                   ( location = without_brackets_2
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_2
                                        code = value #(
                                        ( `IF X <= 1 .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_3
+                                   ( location = without_brackets_3
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_3
                                        code = value #(
                                        ( `IF X = GETINT( ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_4
+                                   ( location = without_brackets_4
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_4
                                        code = value #(
                                        ( `ELSEIF X >= GETINT( ZAHL1 = 2 ZAHL2 = 3 ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_5
+                                   ( location = without_brackets_5
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_5
                                        code = value #(
                                        ( `IF X NOT IN INT_TAB .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_6
+                                   ( location = without_brackets_6
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_6
                                        code = value #(
                                        ( `IF OBJ IS NOT INITIAL .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_7
+                                   ( location = without_brackets_7
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_7
                                        code = value #(
                                        ( `ELSEIF OBJ IS NOT BOUND .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_8
+                                   ( location = without_brackets_8
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_8
                                        code = value #(
                                        ( `IF X > GETBOOL( ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_9
+                                   ( location = without_brackets_9
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_9
                                        code = value #(
                                        ( `IF X EQ XSDBOOL( 1 = 2 ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_10
+                                   ( location = without_brackets_10
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_10
                                        code = value #(
                                        ( `IF X GE 1 OR NOT X GE GETBOOL( XSDBOOL( 1 = 2 ) ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_11
+                                   ( location = without_brackets_11
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_11
                                        code = value #(
                                        ( `IF NOT X LT 1 OR X LT GETBOOL( XSDBOOL( 1 = 2 ) ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_12
+                                   ( location = without_brackets_12
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_12
                                        code = value #(
                                        ( `IF X GT 1 AND NOT X EQ 2 .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_13
+                                   ( location = without_brackets_13
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_13
                                        code = value #(
                                        ( `IF NOT X LE 1 AND X NE 2 .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = without_brackets_14
+                                   ( location = without_brackets_14
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = without_brackets_14
                                        code = value #(
                                        ( `ASSERT 1 = 2 .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_1
+                                   ( location = with_brackets_1
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_1
                                        code = value #(
                                        ( ` ASSERT ( GETINT( ) <> GETBOOL( ) ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_2
+                                   ( location = with_brackets_2
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_2
                                        code = value #(
                                        ( `IF ( X <> 1 ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_3
+                                   ( location = with_brackets_3
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_3
                                        code = value #(
                                        ( `IF ( X = GETINT( ) ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_4
+                                   ( location = with_brackets_4
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_4
                                        code = value #(
                                        ( `ELSEIF ( X >= GETINT( ZAHL1 = 2 ZAHL2 = 3 ) ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_5
+                                   ( location = with_brackets_5
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_5
                                        code = value #(
                                        ( `IF ( X NOT IN INT_TAB ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_6
+                                   ( location = with_brackets_6
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_6
                                        code = value #(
                                        ( `IF ( OBJ IS NOT INITIAL ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_7
+                                   ( location = with_brackets_7
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_7
                                        code = value #(
                                        ( `ELSEIF ( OBJ IS NOT BOUND ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_8
+                                   ( location = with_brackets_8
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_8
                                        code = value #(
                                        ( `IF ( X > GETBOOL( ) ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_9
+                                   ( location = with_brackets_9
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_9
                                        code = value #(
                                        ( `IF ( X EQ XSDBOOL( 1 = XSDBOOL( 1 = 2 ) ) ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_10
+                                   ( location = with_brackets_10
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_10
                                        code = value #(
                                        ( `IF NOT ( X LE 1 AND X NE 2 ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_11
+                                   ( location = with_brackets_11
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_11
                                        code = value #(
                                        ( `ASSERT ( 1 = 2 ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_12
+                                   ( location = with_brackets_12
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_12
                                        code = value #(
                                        ( `IF ( ( 1 + 2 ) <> 3 ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_13
+                                   ( location = with_brackets_13
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_13
                                        code = value #(
                                        ( `IF ( ( 1 + 2 ) + 3 <> 3 ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_brackets_14
+                                   ( location = with_brackets_14
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_brackets_14
                                        code = value #(
                                        ( `IF ( ( 1 + 2 ) + ( 3 + 3 ) <> 3 ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_pseudo_commets_1
+                                   ( location = with_pseudo_commets_1
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_pseudo_commets_1
                                        code = value #(
                                        ( `ASSERT GETINT( ) <> GETBOOL( ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_pseudo_commets_2
+                                   ( location = with_pseudo_commets_2
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_pseudo_commets_2
                                        code = value #(
                                        ( `IF X <> 1 .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_pseudo_commets_3
+                                   ( location = with_pseudo_commets_3
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_pseudo_commets_3
                                        code = value #(
                                        ( `IF X = GETINT( ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_pseudo_commets_4
+                                   ( location = with_pseudo_commets_4
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_pseudo_commets_4
                                        code = value #(
                                        ( `ELSEIF X >= GETINT( ZAHL1 = 2 ZAHL2 = 3 ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_pseudo_commets_5
+                                   ( location = with_pseudo_commets_5
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_pseudo_commets_5
                                        code = value #(
                                        ( `IF X NOT IN INT_TAB .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_pseudo_commets_6
+                                   ( location = with_pseudo_commets_6
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_pseudo_commets_6
                                        code = value #(
                                        ( `IF OBJ IS NOT INITIAL .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_pseudo_commets_7
+                                   ( location = with_pseudo_commets_7
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_pseudo_commets_7
                                        code = value #(
                                        ( `ELSEIF OBJ IS NOT BOUND .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_pseudo_commets_8
+                                   ( location = with_pseudo_commets_8
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_pseudo_commets_8
                                        code = value #(
                                        ( `IF ( X > GETBOOL( ) ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_pseudo_commets_9
+                                   ( location = with_pseudo_commets_9
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_pseudo_commets_9
                                        code = value #(
                                        ( `IF ( X EQ XSDBOOL( 1 = XSDBOOL( 1 = 2 ) ) ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_pseudo_commets_10
+                                   ( location = with_pseudo_commets_10
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_pseudo_commets_10
                                        code = value #(
                                        ( `IF NOT ( X LE 1 AND X NE 2 ) .` ) ) ) ) )
-                                   ( code = /cc4a/prefer_is_not=>finding_code
-                                     location = with_pseudo_commets_11
+                                   ( location = with_pseudo_commets_11
                                      quickfixes = value #( (
                                        quickfix_code = /cc4a/prefer_is_not=>quickfix_code
                                        location = with_pseudo_commets_11

--- a/src/core/#cc4a#check_meta_data.clas.abap
+++ b/src/core/#cc4a#check_meta_data.clas.abap
@@ -4,7 +4,7 @@ class /cc4a/check_meta_data definition
   create private.
 
   public section.
-    interfaces if_ci_atc_check_meta_data.
+    interfaces /cc4a/if_check_meta_data.
 
     types:
       begin of enum ty_checked_types structure checked_types,
@@ -38,7 +38,7 @@ class /cc4a/check_meta_data definition
 
     class-methods create
       importing meta_data type ty_meta_data
-      returning value(result) type ref to if_ci_atc_check_meta_data.
+      returning value(result) type ref to /cc4a/if_check_meta_data.
     methods constructor
       importing meta_data type ty_meta_data.
 
@@ -46,11 +46,11 @@ class /cc4a/check_meta_data definition
 
   private section.
     data meta_data type ty_meta_data.
-ENDCLASS.
+endclass.
 
 
 
-CLASS /CC4A/CHECK_META_DATA IMPLEMENTATION.
+class /cc4a/check_meta_data implementation.
 
 
   method constructor.
@@ -65,6 +65,9 @@ CLASS /CC4A/CHECK_META_DATA IMPLEMENTATION.
       create data value type handle type_handle.
       value->* = <attribute>-value->*.
       <attribute>-value = value.
+    endloop.
+    loop at me->meta_data-finding_codes assigning field-symbol(<finding_code>).
+      <finding_code>-pseudo_comment = |CI_{ <finding_code>-pseudo_comment }|.
     endloop.
   endmethod.
 
@@ -110,4 +113,13 @@ CLASS /CC4A/CHECK_META_DATA IMPLEMENTATION.
   method if_ci_atc_check_meta_data~uses_checksums.
     uses_checksums = abap_true.
   endmethod.
-ENDCLASS.
+
+
+  method /cc4a/if_check_meta_data~has_valid_pseudo_comment.
+    data(pseudo_comment) = meta_data-finding_codes[ code = finding_code ]-pseudo_comment.
+    has_valid_pseudo_comment = xsdbool(
+      line_exists( statement-pseudo_comments[ table_line = pseudo_comment ] ) or
+      line_exists( statement-pseudo_comments[ table_line = pseudo_comment+3 ] ) ).
+  endmethod.
+
+endclass.

--- a/src/core/#cc4a#if_check_meta_data.intf.abap
+++ b/src/core/#cc4a#if_check_meta_data.intf.abap
@@ -1,0 +1,12 @@
+interface /cc4a/if_check_meta_data
+  public.
+
+  interfaces if_ci_atc_check_meta_data.
+
+  methods has_valid_pseudo_comment
+    importing
+      statement type if_ci_atc_source_code_provider=>ty_statement
+      finding_code type if_ci_atc_check_meta_data=>ty_finding_code_info-code
+    returning value(has_valid_pseudo_comment) type abap_bool.
+
+endinterface.

--- a/src/core/#cc4a#if_check_meta_data.intf.xml
+++ b/src/core/#cc4a#if_check_meta_data.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>/CC4A/IF_CHECK_META_DATA</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Shared meta data for checks</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
The Extended Program Check (SLIN) emits findings for pseudo comments that do not start with `CI_` claiming they are invalid. While on a technical level it is possible to use other pseudo comments in CI checks, it is of course not our goal that users of Code Pal receive warning from an SAP standard check due to a pseudo comment they wrote to suppress a Code Pal finding.

However, for compatibility, we should still accept the old pseudo comments without CI_ prefix. We should just no longer recommend them in the finding's description text. 

This PR encapsulates the pseudo comment evaluation into the meta data object. Checks only need to tell the meta data object the pseudo comment _without prefix_ when instantiating it, and then it will always look for both accepted versions of the pseudo comment when queried for a specific statement via `has_valid_pseudo_comment`.