### PR TITLE
Fix bug in PREFER_IS_NOT

### DIFF
--- a/src/checks/#cc4a#prefer_is_not.clas.abap
+++ b/src/checks/#cc4a#prefer_is_not.clas.abap
@@ -42,12 +42,13 @@ class /cc4a/prefer_is_not definition
     "! This method is determining if the given statement contains a finding. Therefore it is searching the comparison
     "! operator which has to be negated due to the NOT condition. Since the comparison operator has to be negated when
     "! fixing the finding, it is important that the statement has no connectives (AND, OR, EQUIV) after the given start
-    "! position which makes a negation too complex (e.g keyword ( 1 = 2 and 3 = 2 ) ). Therefore the method loops over
-    "! the given statement and analyzes the next token from the start position. If the next token is the comparison
-    "! operator, the operator with the position will be returned as a mark that a finding could be determined. Otherwise
-    "! the next token is analyzed until the comparison operator is found. If a connection is found which makes it too
-    "! complex to negate the operator, the method returns an empty structure and no finding should be reported. This
-    "! also happens if no comparison operator is found.
+    "! position which makes a negation too complex (e.g keyword ( 1 = 2 and 3 = 2 ) ).
+    "!
+    "! Therefore the method loops over the given statement and analyzes the next token from the start position. If the
+    "! next token is the comparison operator, the operator with the position will be returned as a mark that a finding
+    "! could be determined. Otherwise the next token is analyzed until the comparison operator is found. If a connection
+    "! is found which makes it too complex to negate the operator, the method returns an empty structure and no finding
+    "! should be reported. This also happens if no comparison operator is found.
     methods determine_finding
       importing statement                 type if_ci_atc_source_code_provider=>ty_statement
                 start_position            type i
@@ -172,8 +173,7 @@ CLASS /CC4A/PREFER_IS_NOT IMPLEMENTATION.
       if next_token is not initial
           and analyzer->is_bracket( next_token ) <> /cc4a/if_abap_analyzer=>bracket_type-opening.
         next_token = value #( statement-tokens[ current_index + 1 ] optional ).
-        if statement-tokens[ start_position + 1 ]-lexeme eq '('
-            and ( next_token-lexeme eq 'AND' or next_token-lexeme eq 'OR' or next_token-lexeme eq 'EQUIV' ).
+        if analyzer->is_logical_connective( next_token ).
           clear operator_to_negate.
           exit.
         elseif next_token is not initial

--- a/src/checks/#cc4a#prefer_is_not.clas.testclasses.abap
+++ b/src/checks/#cc4a#prefer_is_not.clas.testclasses.abap
@@ -1,9 +1,10 @@
-class test definition final for testing
+class tests definition final for testing
   duration short
   risk level harmless.
 
   private section.
     constants test_class type c length 30 value '/CC4A/TEST_PREFER_IS_NOT'.
+    constants negative_test_class type c length 30 value '/CC4A/TEST_PREFER_IS_NOT_2'.
     constants:
       begin of test_class_methods,
         without_brackets     type c length 30 value 'WITHOUT_BRACKETS',
@@ -11,12 +12,14 @@ class test definition final for testing
         with_pseudo_comments type c length 30 value 'WITH_PSEUDO_COMMENTS',
       end of test_class_methods.
 
-    methods execute_test_class for testing raising cx_static_check.
+    methods main_test for testing raising cx_static_check.
+
+    methods no_findings for testing raising cx_static_check.
 endclass.
 
-class test implementation.
+class tests implementation.
 
-  method execute_test_class.
+  method main_test.
 
     data(without_brackets_1) = value if_ci_atc_check=>ty_location(
           object = cl_ci_atc_unit_driver=>get_method_object(
@@ -416,5 +419,13 @@ class test implementation.
                                        ( `ASSERT ( 1 = 2 ) .` ) ) ) ) ) )
       asserter_config   = value #( quickfixes = abap_false ) ).
 
+  endmethod.
+
+  method no_findings.
+    cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
+      check = new /cc4a/prefer_is_not( )
+      object = value #( type = 'CLAS' name = negative_test_class )
+      expected_findings = value #( )
+      asserter_config = value #( ) ).
   endmethod.
 endclass.

--- a/src/core/#cc4a#abap_analyzer.clas.abap
+++ b/src/core/#cc4a#abap_analyzer.clas.abap
@@ -7,6 +7,7 @@ class /cc4a/abap_analyzer definition
     interfaces /cc4a/if_abap_analyzer.
 
     class-methods create returning value(instance) type ref to /cc4a/if_abap_analyzer.
+    class-methods class_constructor.
     aliases find_clause_index for /cc4a/if_abap_analyzer~find_clause_index.
     aliases is_token_keyword for /cc4a/if_abap_analyzer~is_token_keyword.
     aliases is_db_statement for /cc4a/if_abap_analyzer~is_db_statement.
@@ -221,19 +222,6 @@ class /cc4a/abap_analyzer implementation.
 
   method create.
     instance = new /cc4a/abap_analyzer( ).
-
-    negations = value #( ( operator = '>' negated = '<=' )
-                         ( operator = 'GT' negated = 'LE' )
-                         ( operator = '<' negated = '>=' )
-                         ( operator = 'LT' negated = 'GE' )
-                         ( operator = '=' negated = '<>' )
-                         ( operator = 'EQ' negated = 'NE' )
-                         ( operator = '<>' negated = '=' )
-                         ( operator = 'NE' negated = 'EQ' )
-                         ( operator = '<=' negated = '>' )
-                         ( operator = 'LE' negated = 'GT' )
-                         ( operator = '>=' negated = '<' )
-                         ( operator = 'GE' negated = 'LT' ) ).
   endmethod.
 
 
@@ -271,6 +259,21 @@ class /cc4a/abap_analyzer implementation.
   method /cc4a/if_abap_analyzer~is_logical_connective.
     is_logical_connective = xsdbool(
       token-references is initial and ( token-lexeme = 'AND' or token-lexeme = 'OR' or token-lexeme = 'EQUIV' ) ).
+  endmethod.
+
+  method class_constructor.
+    negations = value #( ( operator = '>' negated = '<=' )
+                         ( operator = 'GT' negated = 'LE' )
+                         ( operator = '<' negated = '>=' )
+                         ( operator = 'LT' negated = 'GE' )
+                         ( operator = '=' negated = '<>' )
+                         ( operator = 'EQ' negated = 'NE' )
+                         ( operator = '<>' negated = '=' )
+                         ( operator = 'NE' negated = 'EQ' )
+                         ( operator = '<=' negated = '>' )
+                         ( operator = 'LE' negated = 'GT' )
+                         ( operator = '>=' negated = '<' )
+                         ( operator = 'GE' negated = 'LT' ) ).
   endmethod.
 
 endclass.

--- a/src/core/#cc4a#abap_analyzer.clas.abap
+++ b/src/core/#cc4a#abap_analyzer.clas.abap
@@ -43,89 +43,6 @@ class /cc4a/abap_analyzer implementation.
   endmethod.
 
 
-  method /cc4a/if_abap_analyzer~calculate_bracket_end.
-    if is_bracket( statement-tokens[ bracket_position ] ) ne /cc4a/if_abap_analyzer=>bracket_type-opening and
-       is_bracket( statement-tokens[ bracket_position ] ) ne /cc4a/if_abap_analyzer=>bracket_type-closing.
-      raise exception new /cc4a/cx_token_is_no_bracket( ).
-    endif.
-
-    data(bracket_counter) = 1.
-    loop at statement-tokens assigning field-symbol(<token>) from bracket_position + 1.
-      data(idx) = sy-tabix.
-      case is_bracket( <token> ).
-        when /cc4a/if_abap_analyzer=>bracket_type-opening.
-          bracket_counter += 1.
-
-        when /cc4a/if_abap_analyzer=>bracket_type-closing.
-          if bracket_counter eq 1.
-            end_of_bracket = idx.
-            exit.
-          endif.
-          bracket_counter -= 1.
-
-        when /cc4a/if_abap_analyzer=>bracket_type-clopening.
-          if bracket_counter eq 1.
-            end_of_bracket = idx.
-            exit.
-          endif.
-      endcase.
-    endloop.
-    if end_of_bracket is initial.
-      end_of_bracket = -1.
-    endif.
-  endmethod.
-
-
-  method /cc4a/if_abap_analyzer~find_clause_index.
-    token_index = 0.
-    split condense( clause ) at space into table data(clauses).
-    if clauses is initial or clauses[ 1 ] is initial.
-      raise exception type /cc4a/cx_clause_is_initial.
-    endif.
-    loop at tokens transporting no fields from start_index
-      where references is initial
-      and lexeme = clauses[ 1 ].
-      token_index = sy-tabix.
-      data(clause_index) = 2.
-      while clause_index <= lines( clauses )
-      and token_index + clause_index - 1 <= lines( tokens ).
-        assign tokens[ token_index + clause_index - 1 ] to field-symbol(<token1>).
-        if <token1>-lexeme = clauses[ clause_index ]
-        and <token1>-references is initial.
-          clause_index += 1.
-        else.
-          token_index = 0.
-          exit.
-        endif.
-      endwhile.
-      if token_index <> 0.
-        return.
-      endif.
-    endloop.
-  endmethod.
-
-
-  method /cc4a/if_abap_analyzer~find_key_words.
-    position = -1.
-    loop at statement-tokens transporting no fields where lexeme eq key_words[ 1 ] and references is initial.
-      data(token_index) = sy-tabix.
-      if lines( key_words ) eq 1.
-        position = token_index.
-        return.
-      else.
-        loop at key_words assigning field-symbol(<key_word>) from 2.
-          data(next_token) = value #( statement-tokens[ token_index + sy-tabix - 1 ] optional ).
-          if next_token-references is not initial or next_token-lexeme ne <key_word>.
-            exit.
-          elseif sy-tabix eq lines( key_words ).
-            position = token_index.
-          endif.
-        endloop.
-      endif.
-    endloop.
-  endmethod.
-
-
   method /cc4a/if_abap_analyzer~flatten_tokens.
     if line_exists( tokens[ lexeme = '|' ] ).
       data new_tokens like tokens.
@@ -179,6 +96,60 @@ class /cc4a/abap_analyzer implementation.
   endmethod.
 
 
+  method /cc4a/if_abap_analyzer~calculate_bracket_end.
+    if is_bracket( statement-tokens[ bracket_position ] ) ne /cc4a/if_abap_analyzer=>bracket_type-opening and
+       is_bracket( statement-tokens[ bracket_position ] ) ne /cc4a/if_abap_analyzer=>bracket_type-closing.
+      raise exception new /cc4a/cx_token_is_no_bracket( ).
+    endif.
+
+    data(bracket_counter) = 1.
+    loop at statement-tokens assigning field-symbol(<token>) from bracket_position + 1.
+      data(idx) = sy-tabix.
+      case is_bracket( <token> ).
+        when /cc4a/if_abap_analyzer=>bracket_type-opening.
+          bracket_counter += 1.
+
+        when /cc4a/if_abap_analyzer=>bracket_type-closing.
+          if bracket_counter eq 1.
+            end_of_bracket = idx.
+            exit.
+          endif.
+          bracket_counter -= 1.
+
+        when /cc4a/if_abap_analyzer=>bracket_type-clopening.
+          if bracket_counter eq 1.
+            end_of_bracket = idx.
+            exit.
+          endif.
+      endcase.
+    endloop.
+    if end_of_bracket is initial.
+      end_of_bracket = -1.
+    endif.
+  endmethod.
+
+
+  method /cc4a/if_abap_analyzer~find_key_words.
+    position = -1.
+    loop at statement-tokens transporting no fields where lexeme eq key_words[ 1 ] and references is initial.
+      data(token_index) = sy-tabix.
+      if lines( key_words ) eq 1.
+        position = token_index.
+        return.
+      else.
+        loop at key_words assigning field-symbol(<key_word>) from 2.
+          data(next_token) = value #( statement-tokens[ token_index + sy-tabix - 1 ] optional ).
+          if next_token-references is not initial or next_token-lexeme ne <key_word>.
+            exit.
+          elseif sy-tabix eq lines( key_words ).
+            position = token_index.
+          endif.
+        endloop.
+      endif.
+    endloop.
+  endmethod.
+
+
   method /cc4a/if_abap_analyzer~is_bracket.
     data(first_char) = token-lexeme(1).
     data(offset_for_last_char) = strlen( token-lexeme ) - 1.
@@ -191,14 +162,6 @@ class /cc4a/abap_analyzer implementation.
             when ')' then /cc4a/if_abap_analyzer=>bracket_type-clopening
             else /cc4a/if_abap_analyzer=>bracket_type-opening )
         else /cc4a/if_abap_analyzer=>bracket_type-no_bracket ).
-  endmethod.
-
-
-  method /cc4a/if_abap_analyzer~is_token_keyword.
-    result = abap_true.
-    if token-references is not initial or token-lexeme <> keyword.
-      result = abap_false.
-    endif.
   endmethod.
 
 
@@ -220,8 +183,40 @@ class /cc4a/abap_analyzer implementation.
   endmethod.
 
 
-  method create.
-    instance = new /cc4a/abap_analyzer( ).
+  method /cc4a/if_abap_analyzer~find_clause_index.
+    token_index = 0.
+    split condense( clause ) at space into table data(clauses).
+    if clauses is initial or clauses[ 1 ] is initial.
+      raise exception type /cc4a/cx_clause_is_initial.
+    endif.
+    loop at tokens transporting no fields from start_index
+      where references is initial
+      and lexeme = clauses[ 1 ].
+      token_index = sy-tabix.
+      data(clause_index) = 2.
+      while clause_index <= lines( clauses )
+      and token_index + clause_index - 1 <= lines( tokens ).
+        assign tokens[ token_index + clause_index - 1 ] to field-symbol(<token1>).
+        if <token1>-lexeme = clauses[ clause_index ]
+        and <token1>-references is initial.
+          clause_index += 1.
+        else.
+          token_index = 0.
+          exit.
+        endif.
+      endwhile.
+      if token_index <> 0.
+        return.
+      endif.
+    endloop.
+  endmethod.
+
+
+  method /cc4a/if_abap_analyzer~is_token_keyword.
+    result = abap_true.
+    if token-references is not initial or token-lexeme <> keyword.
+      result = abap_false.
+    endif.
   endmethod.
 
 
@@ -261,6 +256,10 @@ class /cc4a/abap_analyzer implementation.
       token-references is initial and ( token-lexeme = 'AND' or token-lexeme = 'OR' or token-lexeme = 'EQUIV' ) ).
   endmethod.
 
+  method create.
+    instance = new /cc4a/abap_analyzer( ).
+  endmethod.
+
   method class_constructor.
     negations = value #( ( operator = '>' negated = '<=' )
                          ( operator = 'GT' negated = 'LE' )
@@ -275,5 +274,4 @@ class /cc4a/abap_analyzer implementation.
                          ( operator = '>=' negated = '<' )
                          ( operator = 'GE' negated = 'LT' ) ).
   endmethod.
-
-endclass.
+ENDCLASS.

--- a/src/core/#cc4a#abap_analyzer.clas.locals_imp.abap
+++ b/src/core/#cc4a#abap_analyzer.clas.locals_imp.abap
@@ -1,9 +1,9 @@
 *"* use this source file for the definition and implementation of
 *"* local helper classes, interface definitions and type
 *"* declarations
-class lcl_analyze_db_statement definition deferred.
-class /cc4a/abap_analyzer definition local friends lcl_analyze_db_statement.
-class lcl_analyze_db_statement definition final.
+class db_statement_analyzer definition deferred.
+class /cc4a/abap_analyzer definition local friends db_statement_analyzer.
+class db_statement_analyzer definition final.
   public section.
 
     methods constructor
@@ -47,7 +47,7 @@ class lcl_analyze_db_statement definition final.
     data dbtab_name           type string.
     data include_subqueries   type abap_bool.
 endclass.
-class lcl_analyze_db_statement implementation.
+class db_statement_analyzer implementation.
 
   method constructor.
     me->statement = statement.

--- a/src/core/#cc4a#if_abap_analyzer.intf.abap
+++ b/src/core/#cc4a#if_abap_analyzer.intf.abap
@@ -91,4 +91,7 @@ interface /cc4a/if_abap_analyzer
       keyword       type string
     returning
       value(result) type abap_bool .
+  methods is_logical_connective
+    importing token type if_ci_atc_source_code_provider=>ty_token
+    returning value(is_logical_connective) type abap_bool.
 endinterface.

--- a/src/test_objects/#cc4a#test_prefer_is_not_2.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_is_not_2.clas.abap
@@ -1,0 +1,23 @@
+class /cc4a/test_prefer_is_not_2 definition
+  public
+  final
+  create public .
+
+public section.
+protected section.
+private section.
+  methods meth.
+endclass.
+
+
+
+class /cc4a/test_prefer_is_not_2 implementation.
+
+  method meth.
+    data(var_1) = 1.
+    data(var_2) = 2.
+    if var_1 is not initial and var_2 <> 2.
+    endif.
+  endmethod.
+
+endclass.

--- a/src/test_objects/#cc4a#test_prefer_is_not_2.clas.xml
+++ b/src/test_objects/#cc4a#test_prefer_is_not_2.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>/CC4A/TEST_PREFER_IS_NOT_2</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Test object for /CC4A/PREFER_IS_NOT</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
The PREFER_IS_NOT check reported false positives when a logical condition contained an IS NOT INITIAL clause followed by any second condition connected with and/or/equiv.