### PR TITLE
Fix AVOID_SELF_REFERENCE

### DIFF
--- a/src/checks/#cc4a#avoid_self_reference.clas.testclasses.abap
+++ b/src/checks/#cc4a#avoid_self_reference.clas.testclasses.abap
@@ -132,9 +132,6 @@ class test implementation.
     data(local_finding_2) = value if_ci_atc_check=>ty_location(
         object   = value #( type = 'PROG' name = '/CC4A/TEST_AVOID_SELF_REF=====CCIMP' )
         position = value #( line = 37 column = 4 ) ).
-    data(local_finding_3) = value if_ci_atc_check=>ty_location(
-        object   = value #( type = 'PROG' name = '/CC4A/TEST_AVOID_SELF_REF=====CCIMP' )
-        position = value #( line = 58 column = 4 ) ).
     data(local_finding_4) = value if_ci_atc_check=>ty_location(
         object   = value #( type = 'PROG' name = '/CC4A/TEST_AVOID_SELF_REF=====CCIMP' )
         position = value #( line = 63 column = 4 ) ).
@@ -362,13 +359,6 @@ class test implementation.
                 location = local_finding_2
                 code = value #(
                 ( `ATT1 = 2 .` ) ) ) ) )
-            ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
-                location = local_finding_3
-                quickfixes = value #( (
-                quickfix_code = /cc4a/avoid_self_reference=>quickfix_codes-self_reference
-                location = local_finding_3
-                code = value #(
-                ( `ATT3 = 'Hugo' .` ) ) ) ) )
             ( code = /cc4a/avoid_self_reference=>finding_codes-self_reference
                 location = local_finding_4
                 quickfixes = value #( (

--- a/src/checks/#cc4a#equals_sign_chaining.clas.testclasses.abap
+++ b/src/checks/#cc4a#equals_sign_chaining.clas.testclasses.abap
@@ -8,7 +8,8 @@ class ltcl_test definition final for testing
       begin of co_test_object,
         object_type type if_ci_atc_check=>ty_object-type value 'CLAS',
         object_name type if_ci_atc_check=>ty_object-name value '/CC4A/TEST_EQUAL_SIGN_CHAINING',
-      end of co_test_object,
+      end of co_test_object.
+    constants:
       begin of co_test_method_name,
         finding_1 type cl_ci_atc_unit_driver=>ty_method_name value 'FINDING_1',
         finding_2 type cl_ci_atc_unit_driver=>ty_method_name value 'FINDING_2',

--- a/src/checks/#cc4a#method_signature.clas.testclasses.abap
+++ b/src/checks/#cc4a#method_signature.clas.testclasses.abap
@@ -8,7 +8,8 @@ class test definition final for testing
       begin of co_test_object,
         object_type type if_ci_atc_check=>ty_object-type value 'CLAS',
         object_name type if_ci_atc_check=>ty_object-name value '/CC4A/TEST_METHOD_SIGNATURE',
-      end of co_test_object,
+      end of co_test_object.
+    constants:
       begin of co_test_method_name,
         finding_1  type cl_ci_atc_unit_driver=>ty_method_name value 'PUBLIC_INST_NOT_INTERFACE_METH',
         finding_2  type cl_ci_atc_unit_driver=>ty_method_name value 'MULTI_OUPUT_PARAMS_TYPES_1',

--- a/src/core/#cc4a#abap_analyzer.clas.abap
+++ b/src/core/#cc4a#abap_analyzer.clas.abap
@@ -281,6 +281,11 @@ class /cc4a/abap_analyzer implementation.
       return.
     endif.
     data(current_kind) = /cc4a/if_abap_analyzer=>parameter_kind-importing.
+    method_definition-name = statement-tokens[ 2 ]-lexeme.
+    if lines( statement-tokens ) >= 3 and statement-tokens[ 3 ]-lexeme = 'REDEFINITION'.
+      method_definition-is_redefinition = abap_true.
+      return.
+    endif.
     loop at statement-tokens assigning field-symbol(<token>).
       data(token_idx) = sy-tabix.
       if <token>-references is initial.
@@ -299,14 +304,17 @@ class /cc4a/abap_analyzer implementation.
             if parameter_token_length > 10 and <parameter_token>-lexeme(10) = 'REFERENCE('.
               data(reference_offset) = parameter_token_length - 11.
               insert value #(
-                name = <parameter_token>-lexeme+10(reference_offset) kind = current_kind ) into table method_parameters.
+                name = <parameter_token>-lexeme+10(reference_offset)
+                kind = current_kind ) into table method_definition-parameters.
             elseif parameter_token_length > 6 and <parameter_token>-lexeme(6) = 'VALUE('.
               data(value_offset) = parameter_token_length - 7.
               insert value #(
-                name = <parameter_token>-lexeme+6(value_offset) kind = current_kind ) into table method_parameters.
+                name = <parameter_token>-lexeme+6(value_offset)
+                kind = current_kind ) into table method_definition-parameters.
             else.
               insert value #(
-                name = <parameter_token>-lexeme kind = current_kind ) into table method_parameters.
+                name = <parameter_token>-lexeme
+                kind = current_kind ) into table method_definition-parameters.
             endif.
         endcase.
       endif.

--- a/src/core/#cc4a#abap_analyzer.clas.abap
+++ b/src/core/#cc4a#abap_analyzer.clas.abap
@@ -43,6 +43,89 @@ class /cc4a/abap_analyzer implementation.
   endmethod.
 
 
+  method /cc4a/if_abap_analyzer~calculate_bracket_end.
+    if is_bracket( statement-tokens[ bracket_position ] ) ne /cc4a/if_abap_analyzer=>bracket_type-opening and
+       is_bracket( statement-tokens[ bracket_position ] ) ne /cc4a/if_abap_analyzer=>bracket_type-closing.
+      raise exception new /cc4a/cx_token_is_no_bracket( ).
+    endif.
+
+    data(bracket_counter) = 1.
+    loop at statement-tokens assigning field-symbol(<token>) from bracket_position + 1.
+      data(idx) = sy-tabix.
+      case is_bracket( <token> ).
+        when /cc4a/if_abap_analyzer=>bracket_type-opening.
+          bracket_counter += 1.
+
+        when /cc4a/if_abap_analyzer=>bracket_type-closing.
+          if bracket_counter eq 1.
+            end_of_bracket = idx.
+            exit.
+          endif.
+          bracket_counter -= 1.
+
+        when /cc4a/if_abap_analyzer=>bracket_type-clopening.
+          if bracket_counter eq 1.
+            end_of_bracket = idx.
+            exit.
+          endif.
+      endcase.
+    endloop.
+    if end_of_bracket is initial.
+      end_of_bracket = -1.
+    endif.
+  endmethod.
+
+
+  method /cc4a/if_abap_analyzer~find_clause_index.
+    token_index = 0.
+    split condense( clause ) at space into table data(clauses).
+    if clauses is initial or clauses[ 1 ] is initial.
+      raise exception type /cc4a/cx_clause_is_initial.
+    endif.
+    loop at tokens transporting no fields from start_index
+      where references is initial
+      and lexeme = clauses[ 1 ].
+      token_index = sy-tabix.
+      data(clause_index) = 2.
+      while clause_index <= lines( clauses )
+      and token_index + clause_index - 1 <= lines( tokens ).
+        assign tokens[ token_index + clause_index - 1 ] to field-symbol(<token1>).
+        if <token1>-lexeme = clauses[ clause_index ]
+        and <token1>-references is initial.
+          clause_index += 1.
+        else.
+          token_index = 0.
+          exit.
+        endif.
+      endwhile.
+      if token_index <> 0.
+        return.
+      endif.
+    endloop.
+  endmethod.
+
+
+  method /cc4a/if_abap_analyzer~find_key_words.
+    position = -1.
+    loop at statement-tokens transporting no fields where lexeme eq key_words[ 1 ] and references is initial.
+      data(token_index) = sy-tabix.
+      if lines( key_words ) eq 1.
+        position = token_index.
+        return.
+      else.
+        loop at key_words assigning field-symbol(<key_word>) from 2.
+          data(next_token) = value #( statement-tokens[ token_index + sy-tabix - 1 ] optional ).
+          if next_token-references is not initial or next_token-lexeme ne <key_word>.
+            exit.
+          elseif sy-tabix eq lines( key_words ).
+            position = token_index.
+          endif.
+        endloop.
+      endif.
+    endloop.
+  endmethod.
+
+
   method /cc4a/if_abap_analyzer~flatten_tokens.
     if line_exists( tokens[ lexeme = '|' ] ).
       data new_tokens like tokens.
@@ -96,60 +179,6 @@ class /cc4a/abap_analyzer implementation.
   endmethod.
 
 
-  method /cc4a/if_abap_analyzer~calculate_bracket_end.
-    if is_bracket( statement-tokens[ bracket_position ] ) ne /cc4a/if_abap_analyzer=>bracket_type-opening and
-       is_bracket( statement-tokens[ bracket_position ] ) ne /cc4a/if_abap_analyzer=>bracket_type-closing.
-      raise exception new /cc4a/cx_token_is_no_bracket( ).
-    endif.
-
-    data(bracket_counter) = 1.
-    loop at statement-tokens assigning field-symbol(<token>) from bracket_position + 1.
-      data(idx) = sy-tabix.
-      case is_bracket( <token> ).
-        when /cc4a/if_abap_analyzer=>bracket_type-opening.
-          bracket_counter += 1.
-
-        when /cc4a/if_abap_analyzer=>bracket_type-closing.
-          if bracket_counter eq 1.
-            end_of_bracket = idx.
-            exit.
-          endif.
-          bracket_counter -= 1.
-
-        when /cc4a/if_abap_analyzer=>bracket_type-clopening.
-          if bracket_counter eq 1.
-            end_of_bracket = idx.
-            exit.
-          endif.
-      endcase.
-    endloop.
-    if end_of_bracket is initial.
-      end_of_bracket = -1.
-    endif.
-  endmethod.
-
-
-  method /cc4a/if_abap_analyzer~find_key_words.
-    position = -1.
-    loop at statement-tokens transporting no fields where lexeme eq key_words[ 1 ] and references is initial.
-      data(token_index) = sy-tabix.
-      if lines( key_words ) eq 1.
-        position = token_index.
-        return.
-      else.
-        loop at key_words assigning field-symbol(<key_word>) from 2.
-          data(next_token) = value #( statement-tokens[ token_index + sy-tabix - 1 ] optional ).
-          if next_token-references is not initial or next_token-lexeme ne <key_word>.
-            exit.
-          elseif sy-tabix eq lines( key_words ).
-            position = token_index.
-          endif.
-        endloop.
-      endif.
-    endloop.
-  endmethod.
-
-
   method /cc4a/if_abap_analyzer~is_bracket.
     data(first_char) = token-lexeme(1).
     data(offset_for_last_char) = strlen( token-lexeme ) - 1.
@@ -162,6 +191,14 @@ class /cc4a/abap_analyzer implementation.
             when ')' then /cc4a/if_abap_analyzer=>bracket_type-clopening
             else /cc4a/if_abap_analyzer=>bracket_type-opening )
         else /cc4a/if_abap_analyzer=>bracket_type-no_bracket ).
+  endmethod.
+
+
+  method /cc4a/if_abap_analyzer~is_token_keyword.
+    result = abap_true.
+    if token-references is not initial or token-lexeme <> keyword.
+      result = abap_false.
+    endif.
   endmethod.
 
 
@@ -183,40 +220,8 @@ class /cc4a/abap_analyzer implementation.
   endmethod.
 
 
-  method /cc4a/if_abap_analyzer~find_clause_index.
-    token_index = 0.
-    split condense( clause ) at space into table data(clauses).
-    if clauses is initial or clauses[ 1 ] is initial.
-      raise exception type /cc4a/cx_clause_is_initial.
-    endif.
-    loop at tokens transporting no fields from start_index
-      where references is initial
-      and lexeme = clauses[ 1 ].
-      token_index = sy-tabix.
-      data(clause_index) = 2.
-      while clause_index <= lines( clauses )
-      and token_index + clause_index - 1 <= lines( tokens ).
-        assign tokens[ token_index + clause_index - 1 ] to field-symbol(<token1>).
-        if <token1>-lexeme = clauses[ clause_index ]
-        and <token1>-references is initial.
-          clause_index += 1.
-        else.
-          token_index = 0.
-          exit.
-        endif.
-      endwhile.
-      if token_index <> 0.
-        return.
-      endif.
-    endloop.
-  endmethod.
-
-
-  method /cc4a/if_abap_analyzer~is_token_keyword.
-    result = abap_true.
-    if token-references is not initial or token-lexeme <> keyword.
-      result = abap_false.
-    endif.
+  method create.
+    instance = new /cc4a/abap_analyzer( ).
   endmethod.
 
 
@@ -256,10 +261,6 @@ class /cc4a/abap_analyzer implementation.
       token-references is initial and ( token-lexeme = 'AND' or token-lexeme = 'OR' or token-lexeme = 'EQUIV' ) ).
   endmethod.
 
-  method create.
-    instance = new /cc4a/abap_analyzer( ).
-  endmethod.
-
   method class_constructor.
     negations = value #( ( operator = '>' negated = '<=' )
                          ( operator = 'GT' negated = 'LE' )
@@ -274,4 +275,43 @@ class /cc4a/abap_analyzer implementation.
                          ( operator = '>=' negated = '<' )
                          ( operator = 'GE' negated = 'LT' ) ).
   endmethod.
-ENDCLASS.
+
+  method /cc4a/if_abap_analyzer~parse_method_definition.
+    if statement-keyword <> 'METHODS' and statement-keyword <> 'CLASS-METHODS'.
+      return.
+    endif.
+    data(current_kind) = /cc4a/if_abap_analyzer=>parameter_kind-importing.
+    loop at statement-tokens assigning field-symbol(<token>).
+      data(token_idx) = sy-tabix.
+      if <token>-references is initial.
+        case <token>-lexeme.
+          when 'IMPORTING'.
+            current_kind = /cc4a/if_abap_analyzer=>parameter_kind-importing.
+          when 'EXPORTING'.
+            current_kind = /cc4a/if_abap_analyzer=>parameter_kind-exporting.
+          when 'CHANGING'.
+            current_kind = /cc4a/if_abap_analyzer=>parameter_kind-changing.
+          when 'RETURNING'.
+            current_kind = /cc4a/if_abap_analyzer=>parameter_kind-returning.
+          when 'TYPE'.
+            assign statement-tokens[ token_idx - 1 ] to field-symbol(<parameter_token>).
+            data(parameter_token_length) = strlen( <parameter_token>-lexeme ).
+            if parameter_token_length > 10 and <parameter_token>-lexeme(10) = 'REFERENCE('.
+              data(reference_offset) = parameter_token_length - 11.
+              insert value #(
+                name = <parameter_token>-lexeme+10(reference_offset) kind = current_kind ) into table method_parameters.
+            elseif parameter_token_length > 6 and <parameter_token>-lexeme(6) = 'VALUE('.
+              data(value_offset) = parameter_token_length - 7.
+              insert value #(
+                name = <parameter_token>-lexeme+6(value_offset) kind = current_kind ) into table method_parameters.
+            else.
+              insert value #(
+                name = <parameter_token>-lexeme kind = current_kind ) into table method_parameters.
+            endif.
+        endcase.
+      endif.
+    endloop.
+  endmethod.
+
+endclass.
+

--- a/src/core/#cc4a#abap_analyzer.clas.locals_imp.abap
+++ b/src/core/#cc4a#abap_analyzer.clas.locals_imp.abap
@@ -53,8 +53,8 @@ class db_statement_analyzer implementation.
     me->statement = statement.
     me->start_idx = start_idx.
     me->analyzer = analyzer.
-    me->token_idx = start_idx.
-    me->check_if_dbtab = abap_true.
+    token_idx = start_idx.
+    check_if_dbtab = abap_true.
     me->include_subqueries = include_subqueries.
   endmethod.
 
@@ -98,7 +98,7 @@ class db_statement_analyzer implementation.
 
   method get_result.
 
-    result-is_db = me->is_db.
+    result-is_db = is_db.
 
 *   special case for obsolete READ and LOOP statements
     if dbtab_name is not initial and check_if_dbtab = abap_false.

--- a/src/core/#cc4a#abap_analyzer.clas.testclasses.abap
+++ b/src/core/#cc4a#abap_analyzer.clas.testclasses.abap
@@ -300,38 +300,56 @@ CLASS method_definitions IMPLEMENTATION.
 
     cl_abap_unit_assert=>assert_equals(
       act = analyzer->parse_method_definition(
+        shared=>tokenize( `methods meth redefinition .` ) )
+      exp = value /cc4a/if_abap_analyzer=>ty_method_definition(
+        name = `METH`
+        is_redefinition = abap_true ) ).
+    cl_abap_unit_assert=>assert_equals(
+      act = analyzer->parse_method_definition(
+        shared=>tokenize( `methods meth .` ) )
+      exp = value /cc4a/if_abap_analyzer=>ty_method_definition(
+        name = `METH` ) ).
+    cl_abap_unit_assert=>assert_equals(
+      act = analyzer->parse_method_definition(
         shared=>tokenize( `methods meth importing par type i .` ) )
-      exp = value /cc4a/if_abap_analyzer=>ty_method_parameters(
-        ( name = `PAR` kind = /cc4a/if_abap_analyzer=>parameter_kind-importing ) ) ).
+      exp = value /cc4a/if_abap_analyzer=>ty_method_definition(
+        name = `METH`
+        parameters = value #( ( name = `PAR` kind = /cc4a/if_abap_analyzer=>parameter_kind-importing ) ) ) ).
     cl_abap_unit_assert=>assert_equals(
       act = analyzer->parse_method_definition(
         shared=>tokenize( `methods meth importing reference(par) type i .` ) )
-      exp = value /cc4a/if_abap_analyzer=>ty_method_parameters(
-        ( name = `PAR` kind = /cc4a/if_abap_analyzer=>parameter_kind-importing ) ) ).
+      exp = value /cc4a/if_abap_analyzer=>ty_method_definition(
+        name = `METH`
+        parameters = value #( ( name = `PAR` kind = /cc4a/if_abap_analyzer=>parameter_kind-importing ) ) ) ).
     cl_abap_unit_assert=>assert_equals(
       act = analyzer->parse_method_definition(
         shared=>tokenize( `methods meth exporting par type i .` ) )
-      exp = value /cc4a/if_abap_analyzer=>ty_method_parameters(
-        ( name = `PAR` kind = /cc4a/if_abap_analyzer=>parameter_kind-exporting ) ) ).
+      exp = value /cc4a/if_abap_analyzer=>ty_method_definition(
+        name = `METH`
+        parameters = value #( ( name = `PAR` kind = /cc4a/if_abap_analyzer=>parameter_kind-exporting ) ) ) ).
     cl_abap_unit_assert=>assert_equals(
       act = analyzer->parse_method_definition(
         shared=>tokenize( `methods meth changing par type i .` ) )
-      exp = value /cc4a/if_abap_analyzer=>ty_method_parameters(
-        ( name = `PAR` kind = /cc4a/if_abap_analyzer=>parameter_kind-changing ) ) ).
+      exp = value /cc4a/if_abap_analyzer=>ty_method_definition(
+        name = `METH`
+        parameters = value #( ( name = `PAR` kind = /cc4a/if_abap_analyzer=>parameter_kind-changing ) ) ) ).
     cl_abap_unit_assert=>assert_equals(
       act = analyzer->parse_method_definition(
         shared=>tokenize( `methods meth changing par type i .` ) )
-      exp = value /cc4a/if_abap_analyzer=>ty_method_parameters(
-        ( name = `PAR` kind = /cc4a/if_abap_analyzer=>parameter_kind-changing ) ) ).
+      exp = value /cc4a/if_abap_analyzer=>ty_method_definition(
+        name = `METH`
+        parameters = value #( ( name = `PAR` kind = /cc4a/if_abap_analyzer=>parameter_kind-changing ) ) ) ).
     cl_abap_unit_assert=>assert_equals(
       act = analyzer->parse_method_definition(
         shared=>tokenize(
           `methods meth importing imp type i exporting reference(exp) type i changing ch type i returning value(ret) type i.` ) )
-      exp = value /cc4a/if_abap_analyzer=>ty_method_parameters(
-        ( name = `IMP` kind = /cc4a/if_abap_analyzer=>parameter_kind-importing )
-        ( name = `EXP` kind = /cc4a/if_abap_analyzer=>parameter_kind-exporting )
-        ( name = `CH` kind = /cc4a/if_abap_analyzer=>parameter_kind-changing )
-        ( name = `RET` kind = /cc4a/if_abap_analyzer=>parameter_kind-returning ) ) ).
+      exp = value /cc4a/if_abap_analyzer=>ty_method_definition(
+        name = `METH`
+        parameters = value #(
+          ( name = `IMP` kind = /cc4a/if_abap_analyzer=>parameter_kind-importing )
+          ( name = `EXP` kind = /cc4a/if_abap_analyzer=>parameter_kind-exporting )
+          ( name = `CH` kind = /cc4a/if_abap_analyzer=>parameter_kind-changing )
+          ( name = `RET` kind = /cc4a/if_abap_analyzer=>parameter_kind-returning ) ) ) ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/core/#cc4a#if_abap_analyzer.intf.abap
+++ b/src/core/#cc4a#if_abap_analyzer.intf.abap
@@ -34,6 +34,12 @@ interface /cc4a/if_abap_analyzer
       kind type ty_parameter_kind,
     end of ty_method_parameter.
   types ty_method_parameters type hashed table of ty_method_parameter with unique key name.
+  types:
+    begin of ty_method_definition,
+      name type string,
+      is_redefinition type abap_bool,
+      parameters type ty_method_parameters,
+    end of ty_method_definition.
 
 
   methods find_key_words
@@ -111,5 +117,5 @@ interface /cc4a/if_abap_analyzer
     returning value(is_logical_connective) type abap_bool.
   methods parse_method_definition
     importing statement type if_ci_atc_source_code_provider=>ty_statement
-    returning value(method_parameters) type ty_method_parameters.
+    returning value(method_definition) type ty_method_definition.
 endinterface.

--- a/src/core/#cc4a#if_abap_analyzer.intf.abap
+++ b/src/core/#cc4a#if_abap_analyzer.intf.abap
@@ -5,22 +5,37 @@
 interface /cc4a/if_abap_analyzer
   public .
 
-  types: begin of enum ty_bracket_type structure bracket_type,
-           no_bracket,
-           opening,
-           closing,
-           "! Closed and opening. Due to quirks in the ABAP tokenizer, a chained method call like
-           "! obj->method_1( )->method_2( ) produces a single token `)->method_2(` that is both a closing and an
-           "! opening bracket.
-           clopening,
-         end of enum ty_bracket_type structure bracket_type.
-
+  types:
+    begin of enum ty_bracket_type structure bracket_type,
+      no_bracket,
+      opening,
+      closing,
+      "! Closed and opening. Due to quirks in the ABAP tokenizer, a chained method call like
+      "! obj->method_1( )->method_2( ) produces a single token `)->method_2(` that is both a closing and an
+      "! opening bracket.
+      clopening,
+    end of enum ty_bracket_type structure bracket_type.
   types:
     begin of ty_db_statement,
       is_db          type abap_bool,
       dbtab          type string,
       dbtab_subquery type string,
     end of ty_db_statement.
+  types:
+    begin of enum ty_parameter_kind structure parameter_kind,
+      importing,
+      exporting,
+      changing,
+      returning,
+    end of enum ty_parameter_kind structure parameter_kind.
+  types:
+    begin of ty_method_parameter,
+      name type string,
+      kind type ty_parameter_kind,
+    end of ty_method_parameter.
+  types ty_method_parameters type hashed table of ty_method_parameter with unique key name.
+
+
   methods find_key_words
     importing
       key_words       type string_table
@@ -94,4 +109,7 @@ interface /cc4a/if_abap_analyzer
   methods is_logical_connective
     importing token type if_ci_atc_source_code_provider=>ty_token
     returning value(is_logical_connective) type abap_bool.
+  methods parse_method_definition
+    importing statement type if_ci_atc_source_code_provider=>ty_statement
+    returning value(method_parameters) type ty_method_parameters.
 endinterface.

--- a/src/test_objects/#cc4a#if_test_avoid_self_ref.intf.abap
+++ b/src/test_objects/#cc4a#if_test_avoid_self_ref.intf.abap
@@ -1,0 +1,7 @@
+interface /cc4a/if_test_avoid_self_ref
+  public.
+
+methods meth_1
+  importing var_1 type i.
+
+endinterface.

--- a/src/test_objects/#cc4a#if_test_avoid_self_ref.intf.xml
+++ b/src/test_objects/#cc4a#if_test_avoid_self_ref.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>/CC4A/IF_TEST_AVOID_SELF_REF</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Test object for /CC4A/AVOID_SELF_REFERENCE</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/test_objects/#cc4a#test_avoid_self_ref.clas.locals_imp.abap
+++ b/src/test_objects/#cc4a#test_avoid_self_ref.clas.locals_imp.abap
@@ -84,3 +84,18 @@ class impl_interface implementation.
   endmethod.
 
 endclass.
+
+class inheriting_from_global definition inheriting from /cc4a/test_avoid_self_ref_sup.
+  public section.
+    methods super_meth redefinition.
+  private section.
+    data imp type i.
+endclass.
+
+CLASS inheriting_from_global IMPLEMENTATION.
+
+  METHOD super_meth.
+    me->imp = imp.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/test_objects/#cc4a#test_avoid_self_ref.clas.locals_imp.abap
+++ b/src/test_objects/#cc4a#test_avoid_self_ref.clas.locals_imp.abap
@@ -69,3 +69,18 @@ class lz_self_reference2 implementation.
   endmethod.
 
 endclass.
+
+class impl_interface definition.
+  public section.
+    interfaces /cc4a/if_test_avoid_self_ref.
+  private section.
+    data var_1 type i.
+endclass.
+
+class impl_interface implementation.
+
+  method /cc4a/if_test_avoid_self_ref~meth_1.
+    me->var_1 = var_1.
+  endmethod.
+
+endclass.

--- a/src/test_objects/#cc4a#test_avoid_self_ref_sup.clas.abap
+++ b/src/test_objects/#cc4a#test_avoid_self_ref_sup.clas.abap
@@ -1,0 +1,20 @@
+class /cc4a/test_avoid_self_ref_sup definition
+  public
+  create public .
+
+public section.
+  methods super_meth
+    importing imp type i.
+protected section.
+private section.
+endclass.
+
+
+
+class /cc4a/test_avoid_self_ref_sup implementation.
+
+  method super_meth.
+
+  endmethod.
+
+endclass.

--- a/src/test_objects/#cc4a#test_avoid_self_ref_sup.clas.xml
+++ b/src/test_objects/#cc4a#test_avoid_self_ref_sup.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>/CC4A/TEST_AVOID_SELF_REF_SUP</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Test object for /CC4A/AVOID_SELF_REFERENCE</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
The check for self-references didn't yet consider methods whose signature was defined in global super classes or global interfaces. 