### PR TITLE
Fix short dumps on "IS" and "IN" operators as well as on "BEGIN OF COMMON PART"

### DIFF
--- a/src/checks/#cc4a#check_in_iteration.clas.abap
+++ b/src/checks/#cc4a#check_in_iteration.clas.abap
@@ -284,7 +284,7 @@ class /cc4a/check_in_iteration implementation.
       bool_expression = bool_expression && ` ` && expression.
     endloop.
 
-    data(flat_new_statement) = analyzer->flatten_tokens( new_statement-tokens ) && `WHERE` && bool_expression && '.'.
+    data(flat_new_statement) = analyzer->flatten_tokens( new_statement-tokens ) && ` WHERE` && bool_expression && '.'.
     modified_statement = analyzer->break_into_lines( flat_new_statement ).
   endmethod.
 

--- a/src/checks/#cc4a#check_in_iteration.clas.testclasses.abap
+++ b/src/checks/#cc4a#check_in_iteration.clas.testclasses.abap
@@ -82,6 +82,11 @@ class test implementation.
         value #( class = test_class method = test_class_methods-without_pseudo_comments ) )
       position = value #( line = 60 column = 6 ) ).
 
+    data(without_pseudo_comment_11) = value if_ci_atc_check=>ty_location(
+      object   = cl_ci_atc_unit_driver=>get_method_object(
+        value #( class = test_class method = test_class_methods-without_pseudo_comments ) )
+      position = value #( line = 65 column = 6 ) ).
+
 
     data(with_pseudo_comment_1) = value if_ci_atc_check=>ty_location(
       object   = cl_ci_atc_unit_driver=>get_method_object(
@@ -106,195 +111,171 @@ class test implementation.
 
 
     cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
-              check             = new /cc4a/check_in_iteration( )
-              object            = value #( type = 'CLAS' name = test_class )
-              expected_findings = value #( (
-                                         code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                         location = without_pseudo_comment_1
-                                          quickfixes = value #(
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
-                                          location = without_pseudo_comment_1
-                                          code = value #(
-                                          ( `IF 1 <> 1 .` )
-                                          ( `CONTINUE .` )
-                                          ( `ENDIF .` )
-                                          ( `enddo.` )
-                                          ( `data(a) = 125.` )
-                                          ( `data(b) = 250.` ) ) ) )
-                                          )
-                                          (
-                                          code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                         location = without_pseudo_comment_2
-                                          quickfixes = value #(
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
-                                          location = without_pseudo_comment_2
-                                          code = value #(
-                                          ( `IF A <> B .` )
-                                          ( `CONTINUE .` )
-                                          ( `ENDIF .` )
-                                          ( `ELSE .` )
-                                          ( `CHECK b = 3 .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDDO .` ) ) ) )
-                                          )
-                                        (
-                                          code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                         location = without_pseudo_comment_3
-                                          quickfixes = value #(
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
-                                          location = without_pseudo_comment_3
-                                          code = value #(
-                                          ( `IF B <> 3 .` )
-                                          ( `CONTINUE .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDDO .` ) ) ) )
-                                          )
-                                          (
-                                          code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                         location = without_pseudo_comment_4
-                                          quickfixes = value #(
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
-                                          location = without_pseudo_comment_4
-                                          code = value #(
-                                          ( `IF X <> Y .` )
-                                          ( `CONTINUE .` )
-                                          ( `ENDIF .` )
-                                          ( `IF 3 = 3 .` )
-                                          ( `CHECK x <> 150 .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDWHILE .` ) ) ) )
-                                          )
-                                          (
-                                          code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                         location = without_pseudo_comment_5
-                                          quickfixes = value #(
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
-                                          location = without_pseudo_comment_5
-                                          code = value #(
-                                          ( `IF X = 150 .` )
-                                          ( `CONTINUE .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDWHILE .` )
-                                          ( `types: begin of ty_table,` ) ) ) )
-                                          )                                 (
-                                          code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                         location = without_pseudo_comment_6
-                                          quickfixes = value #(
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
-                                          location = without_pseudo_comment_6
-                                          code = value #(
-                                          ( `IF <TAB>-DELFLAG <> ABAP_TRUE .` )
-                                          ( `CONTINUE .` )
-                                          ( `ENDIF .` )
-                                          ( `IF A = X .` )
-                                          ( `CHECK <tab>-delflag <= abap_false .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDLOOP .` )
-                                           )
-                                          )
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-where_quickfix
-                                          location = without_pseudo_comment_6_where
-                                          code = value #(
-                                          ( `LOOP AT ITAB ASSIGNING FIELD-SYMBOL(<TAB>) WHERE DELFLAG = ABAP_TRUE .` )
-                                          ( ` ` )
-                                          ( `IF A = X .` ) ) )
-                                          ) )
-                                          (
-                                          code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                         location = without_pseudo_comment_7
-                                          quickfixes = value #(
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
-                                          location = without_pseudo_comment_7
-                                          code = value #(
-                                          ( `IF <TAB>-DELFLAG > ABAP_FALSE .` )
-                                          ( `CONTINUE .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDLOOP .` )
-                                           ) ) )
-                                          )
-                                          (
-                                          code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                         location = without_pseudo_comment_8
-                                          quickfixes = value #(
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
-                                          location = without_pseudo_comment_8
-                                          code = value #(
-                                          ( `IF ABAP_FALSE <> TAB-DELFLAG .` )
-                                          ( `CONTINUE .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDLOOP .` )
-                                          ( `LOOP AT ITAB ASSIGNING <TAB> .` )
-                                          ( `CHECK <TAB>-DELFLAG = ABAP_TRUE .` )
-                                          ( `CHECK XSDBOOL( 1 > 3 ) = ABAP_TRUE .` )
-                                          ( `ENDLOOP .` )
-                                           )
-                                          )
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-where_quickfix
-                                          location = without_pseudo_comment_8_where
-                                          code = value #(
-                                          ( `LOOP AT ITAB INTO DATA(TAB) WHERE DELFLAG = ABAP_FALSE .` )
-                                          ( ` ` )
-                                          ( `ENDLOOP .` ) ) ) )
-                                          )
-                                          (
-                                          code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                         location = without_pseudo_comment_9
-                                          quickfixes = value #(
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
-                                          location = without_pseudo_comment_9
-                                          code = value #(
-                                          ( `IF <TAB>-DELFLAG <> ABAP_TRUE .` )
-                                          ( `CONTINUE .` )
-                                          ( `ENDIF .` )
-                                          ( `CHECK XSDBOOL( 1 > 3 ) = ABAP_TRUE .` )
-                                          ( `ENDLOOP .` )
-                                          ( `ENDMETHOD .` )
-                                           )
-                                          )
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-where_quickfix
-                                          location = without_pseudo_comment_9_where
-                                          code = value #(
-                                          ( `LOOP AT ITAB ASSIGNING <TAB> WHERE DELFLAG = ABAP_TRUE .` )
-                                          ( ` ` )
-                                          ( `CHECK XSDBOOL( 1 > 3 ) = ABAP_TRUE .` )
-                                          ( `ENDLOOP.` )
-                                          ) ) )
-                                          )
-                                          (
-                                          code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                         location = without_pseudo_comment_10
-                                          quickfixes = value #(
-                                          ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
-                                          location = without_pseudo_comment_10
-                                          code = value #(
-                                          ( `IF XSDBOOL( 1 > 3 ) <> ABAP_TRUE .` )
-                                          ( `CONTINUE .` )
-                                          ( `ENDIF .` )
-                                          ( `ENDLOOP .` )
-                                          ( `ENDMETHOD .` )
-                                          ) ) )
-                                          )
+      check = new /cc4a/check_in_iteration( )
+      object = value #( type = 'CLAS' name = test_class )
+      asserter_config = value #( quickfixes = abap_false )
+      expected_findings = value #(
+        ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+          location = without_pseudo_comment_1
+          quickfixes = value #(
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
+              location = without_pseudo_comment_1
+              code = value #(
+                ( `IF 1 <> 1 .` )
+                ( `CONTINUE .` )
+                ( `ENDIF .` )
+                ( `enddo.` )
+                ( `data(a) = 125.` )
+                ( `data(b) = 250.` ) ) ) ) )
+        ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+          location = without_pseudo_comment_2
+          quickfixes = value #(
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
+              location = without_pseudo_comment_2
+              code = value #(
+                ( `IF A <> B .` )
+                ( `CONTINUE .` )
+                ( `ENDIF .` )
+                ( `ELSE .` )
+                ( `CHECK b = 3 .` )
+                ( `ENDIF .` )
+                ( `ENDIF .` )
+                ( `ENDDO .` ) ) ) ) )
+        ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+          location = without_pseudo_comment_3
+          quickfixes = value #(
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
+              location = without_pseudo_comment_3
+              code = value #(
+                ( `IF B <> 3 .` )
+                ( `CONTINUE .` )
+                ( `ENDIF .` )
+                ( `ENDIF .` )
+                ( `ENDIF .` )
+                ( `ENDDO .` ) ) ) ) )
+        ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+          location = without_pseudo_comment_4
+          quickfixes = value #(
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
+              location = without_pseudo_comment_4
+              code = value #(
+                ( `IF X <> Y .` )
+                ( `CONTINUE .` )
+                ( `ENDIF .` )
+                ( `IF 3 = 3 .` )
+                ( `CHECK x <> 150 .` )
+                ( `ENDIF .` )
+                ( `ENDWHILE .` ) ) ) ) )
+        ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+          location = without_pseudo_comment_5
+          quickfixes = value #(
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
+              location = without_pseudo_comment_5
+              code = value #(
+                ( `IF X = 150 .` )
+                ( `CONTINUE .` )
+                ( `ENDIF .` )
+                ( `ENDIF .` )
+                ( `ENDWHILE .` )
+                ( `types: begin of ty_table,` ) ) ) ) )
+        ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+          location = without_pseudo_comment_6
+          quickfixes = value #(
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
+              location = without_pseudo_comment_6
+              code = value #(
+                ( `IF <TAB>-DELFLAG <> ABAP_TRUE .` )
+                ( `CONTINUE .` )
+                ( `ENDIF .` )
+                ( `IF A = X .` )
+                ( `CHECK <tab>-delflag <= abap_false .` )
+                ( `ENDIF .` )
+                ( `ENDLOOP .` ) ) )
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-where_quickfix
+            location = without_pseudo_comment_6_where
+            code = value #(
+              ( `LOOP AT ITAB ASSIGNING FIELD-SYMBOL(<TAB>) WHERE DELFLAG = ABAP_TRUE .` )
+              ( ` ` )
+              ( `IF A = X .` ) ) ) ) )
+        ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+          location = without_pseudo_comment_7
+          quickfixes = value #(
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
+              location = without_pseudo_comment_7
+              code = value #(
+                ( `IF <TAB>-DELFLAG > ABAP_FALSE .` )
+                ( `CONTINUE .` )
+                ( `ENDIF .` )
+                ( `ENDIF .` )
+                ( `ENDLOOP .` ) ) ) ) )
+        ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+          location = without_pseudo_comment_8
+          quickfixes = value #(
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
+              location = without_pseudo_comment_8
+              code = value #(
+                ( `IF ABAP_FALSE <> TAB-DELFLAG .` )
+                ( `CONTINUE .` )
+                ( `ENDIF .` )
+                ( `ENDLOOP .` )
+                ( `LOOP AT ITAB ASSIGNING <TAB> .` )
+                ( `CHECK <TAB>-DELFLAG = ABAP_TRUE .` )
+                ( `CHECK XSDBOOL( 1 > 3 ) = ABAP_TRUE .` )
+                ( `ENDLOOP .` ) ) )
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-where_quickfix
+              location = without_pseudo_comment_8_where
+              code = value #(
+                ( `LOOP AT ITAB INTO DATA(TAB) WHERE DELFLAG = ABAP_FALSE .` )
+                ( ` ` )
+                ( `ENDLOOP .` ) ) ) ) )
+        ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+          location = without_pseudo_comment_9
+          quickfixes = value #(
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
+              location = without_pseudo_comment_9
+              code = value #(
+                ( `IF <TAB>-DELFLAG <> ABAP_TRUE .` )
+                ( `CONTINUE .` )
+                ( `ENDIF .` )
+                ( `CHECK XSDBOOL( 1 > 3 ) = ABAP_TRUE .` )
+                ( `ENDLOOP .` ) ) )
+            ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-where_quickfix
+              location = without_pseudo_comment_9_where
+              code = value #(
+                ( `LOOP AT ITAB ASSIGNING <TAB> WHERE DELFLAG = ABAP_TRUE .` )
+                ( ` ` )
+                ( `CHECK XSDBOOL( 1 > 3 ) = ABAP_TRUE .` )
+                ( `ENDLOOP.` ) ) ) ) )
+          ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+            location = without_pseudo_comment_10
+            quickfixes = value #(
+              ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
+                location = without_pseudo_comment_10
+                code = value #(
+                  ( `IF XSDBOOL( 1 > 3 ) <> ABAP_TRUE .` )
+                  ( `CONTINUE .` )
+                  ( `ENDIF .` )
+                  ( `ENDLOOP .` ) ) ) ) )
+          ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+            location = without_pseudo_comment_11
+            quickfixes = value #(
+              ( quickfix_code = /cc4a/check_in_iteration=>quickfix_codes-if_quickfix
+                location = without_pseudo_comment_11
+                code = value #(
+                  ( `IF <TAB> NOT IN ITAB_RANGE .` )
+                  ( `CONTINUE .` )
+                  ( `ENDIF .` )
+                  ( `ENDLOOP .` )
+                  ( `ENDMETHOD .` ) ) ) ) )
 
-                                          ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                            location = with_pseudo_comment_1
-                                           )
-                                          ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                            location = with_pseudo_comment_2
-                                           )
-                                          ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                            location = with_pseudo_comment_3
-                                           )
-                                         ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
-                                            location = with_pseudo_comment_4
-                                           )
-                                          )
-
-              asserter_config   = value #( quickfixes = abap_false ) ).
+          ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+            location = with_pseudo_comment_1 )
+          ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+            location = with_pseudo_comment_2 )
+          ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+            location = with_pseudo_comment_3 )
+          ( code = /cc4a/check_in_iteration=>finding_codes-check_in_iteration
+            location = with_pseudo_comment_4 ) ) ).
   endmethod.
 
 endclass.

--- a/src/checks/#cc4a#proper_bool_expression.clas.abap
+++ b/src/checks/#cc4a#proper_bool_expression.clas.abap
@@ -277,6 +277,10 @@ class /cc4a/proper_bool_expression implementation.
   endmethod.
 
   METHOD analyze_declaration.
+    if analyzer->find_clause_index( tokens = statement-tokens clause = `BEGIN OF COMMON PART` ).
+      return.
+    endif.
+
     data(kind) = cond #(
       when statement-keyword = 'DATA' or statement-keyword = 'FINAL' or statement-keyword = 'CONSTANTS'
         then declaration_kind-classic
@@ -293,6 +297,7 @@ class /cc4a/proper_bool_expression implementation.
     if kind = declaration_kind-none or analyzer->is_token_keyword( token = statement-tokens[ 2 ] keyword = 'END' ).
       return value #( ).
     endif.
+
     data(declared_identifier) = switch #( kind
       when declaration_kind-inline
         then statement-tokens[ 1 ]-references[ 1 ]-full_name

--- a/src/checks/#cc4a#proper_bool_expression.clas.testclasses.abap
+++ b/src/checks/#cc4a#proper_bool_expression.clas.testclasses.abap
@@ -171,7 +171,7 @@ class test implementation.
 
     cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
               check             = new /cc4a/proper_bool_expression( )
-              object            = value #( type = 'CLASS' name = test_class )
+              object            = value #( type = 'CLAS' name = test_class )
               expected_findings = value #(
                 ( lines of transform_to_xsd_findings )
                 ( lines of bool_value_findings )

--- a/src/core/#cc4a#abap_analyzer.clas.abap
+++ b/src/core/#cc4a#abap_analyzer.clas.abap
@@ -63,11 +63,11 @@ class /cc4a/abap_analyzer definition
       importing value(offsets) type ty_offsets
       changing tokens type if_ci_atc_source_code_provider=>ty_tokens
       returning value(expression) type ty_logical_expression.
-endclass.
+ENDCLASS.
 
 
 
-class /cc4a/abap_analyzer implementation.
+CLASS /CC4A/ABAP_ANALYZER IMPLEMENTATION.
 
 
   method /cc4a/if_abap_analyzer~break_into_lines.
@@ -265,18 +265,21 @@ class /cc4a/abap_analyzer implementation.
 
 
   method class_constructor.
-    negations = value #( ( operator = '>' negated = '<=' )
-                         ( operator = 'GT' negated = 'LE' )
-                         ( operator = '<' negated = '>=' )
-                         ( operator = 'LT' negated = 'GE' )
-                         ( operator = '=' negated = '<>' )
-                         ( operator = 'EQ' negated = 'NE' )
-                         ( operator = '<>' negated = '=' )
-                         ( operator = 'NE' negated = 'EQ' )
-                         ( operator = '<=' negated = '>' )
-                         ( operator = 'LE' negated = 'GT' )
-                         ( operator = '>=' negated = '<' )
-                         ( operator = 'GE' negated = 'LT' ) ).
+    negations = value #(
+      ( operator = 'IN' negated = 'NOT IN' )
+      ( operator = 'IS' negated = 'NOT IS' )
+      ( operator = '>' negated = '<=' )
+      ( operator = 'GT' negated = 'LE' )
+      ( operator = '<' negated = '>=' )
+      ( operator = 'LT' negated = 'GE' )
+      ( operator = '=' negated = '<>' )
+      ( operator = 'EQ' negated = 'NE' )
+      ( operator = '<>' negated = '=' )
+      ( operator = 'NE' negated = 'EQ' )
+      ( operator = '<=' negated = '>' )
+      ( operator = 'LE' negated = 'GT' )
+      ( operator = '>=' negated = '<' )
+      ( operator = 'GE' negated = 'LT' ) ).
   endmethod.
 
 
@@ -285,35 +288,7 @@ class /cc4a/abap_analyzer implementation.
   endmethod.
 
 
-  method is_db_statement.
-    case statement-keyword.
-      when 'SELECT' or 'WITH' or 'DELETE' or 'UPDATE' or 'INSERT' or 'MODIFY' or 'READ' or 'LOOP'
-      or 'IMPORT' or 'EXPORT' or 'FETCH' or 'OPEN' or 'EXEC'.
-        if ( find_clause_index( tokens = statement-tokens clause = 'CONNECTION' ) <> 0
-             and (    statement-keyword = 'DELETE'
-                   or statement-keyword = 'UPDATE'
-                   or statement-keyword = 'INSERT'
-                   or statement-keyword = 'MODIFY' ) ).
-          result-is_db = abap_true.
-          if get_dbtab_name = abap_false.
-            return.
-          endif.
-        endif.
-      when others.
-        return.
-    endcase.
-    data(token_idx) = 2.
-    while lines( statement-tokens ) > token_idx and statement-tokens[ token_idx ]-lexeme cp '%_*('
-    and statement-tokens[ token_idx ]-references is initial.
-      token_idx += 3.
-    endwhile.
-    data(analyzer) = new db_statement_analyzer(
-       statement = statement
-       start_idx = token_idx
-       analyzer = me
-       include_subqueries = include_subqueries ).
-    result = analyzer->analyze( ).
-
+  method /CC4A/IF_ABAP_ANALYZER~IS_DB_STATEMENT.
   endmethod.
 
 
@@ -339,6 +314,7 @@ class /cc4a/abap_analyzer implementation.
       flat = flat(len).
     endif.
   endmethod.
+
 
   method _flatten_template.
     data(inside_braces) = abap_false.
@@ -376,7 +352,6 @@ class /cc4a/abap_analyzer implementation.
       assign tokens[ 1 ] to <token>.
     endwhile.
   endmethod.
-
 
 
   method _break_into_lines.
@@ -451,6 +426,7 @@ class /cc4a/abap_analyzer implementation.
     endif.
   endmethod.
 
+
   method /cc4a/if_abap_analyzer~negate_logical_expression.
     data(new_tokens) = tokens.
     data(expression) = parse_logical_expression( tokens ).
@@ -507,12 +483,14 @@ class /cc4a/abap_analyzer implementation.
     return /cc4a/if_abap_analyzer~flatten_tokens( new_tokens ).
   endmethod.
 
+
   method parse_logical_expression.
     data(_tokens) = tokens.
     return _parse_logical_expression(
       exporting offsets = value #( token = 1 table = 1 )
       changing tokens = _tokens ).
   endmethod.
+
 
   method _parse_logical_expression.
     if tokens is initial.
@@ -601,5 +579,4 @@ class /cc4a/abap_analyzer implementation.
         ( tokens = value #( from = offsets-token to = offsets-token + lines( left_tokens ) - 1 ) ) ).
     endif.
   endmethod.
-
-endclass.
+ENDCLASS.

--- a/src/test_objects/#cc4a#test_check_in_iteration.clas.abap
+++ b/src/test_objects/#cc4a#test_check_in_iteration.clas.abap
@@ -8,6 +8,12 @@ class /cc4a/test_check_in_iteration definition
   private section.
     methods without_pseudo_comments.
     methods with_pseudo_comments.
+
+    types: begin of ty_table,
+             delflag type abap_bool,
+           end of ty_table.
+
+    data itab_range type range of ty_table.
 ENDCLASS.
 
 
@@ -75,6 +81,11 @@ CLASS /CC4A/TEST_CHECK_IN_ITERATION IMPLEMENTATION.
     loop at itab assigning <tab>.
       check <tab>-delflag = abap_true.
       check xsdbool( 1 > 3 ) = abap_true.
+    endloop.
+
+
+    loop at itab assigning <tab>.
+      check <tab> in itab_range.
     endloop.
 
   endmethod.


### PR DESCRIPTION
Fixes two issues:

1. A short dump in /CC4A/CHECK_IN_ITERATION when trying to build a quick fix for boolean expressions involving the "IS" or "IN" operators.
2. A shortdump in /CC4A/PROPER_BOOL_EXPRESSION when encountering the (obsolete) statement `DATA BEGIN OF COMMON PART ...`.