### PR TITLE
Add "Prefer CASE to ELSEIF" check (#12)

### DIFF
--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
@@ -26,7 +26,7 @@ CLASS /cc4a/prefer_case_to_elseif DEFINITION
     " Represents one IF / ELSEIF / ELSE branch within an IF block.
     " condition_root holds the left-hand side variable (e.g. TYPE in IF TYPE = 'A').
     " is_else = true for branches that cannot map to a simple WHEN clause:
-    "   ELSE keyword, or IF/ELSEIF conditions joined by AND / OR.
+    "   ELSE keyword, AND conditions, or OR conditions testing different variables.
     TYPES:
       BEGIN OF ty_branch,
         stmt_index     TYPE i,
@@ -53,7 +53,7 @@ CLASS /cc4a/prefer_case_to_elseif DEFINITION
       IMPORTING !procedure    TYPE if_ci_atc_source_code_provider=>ty_procedure
       RETURNING VALUE(result) TYPE if_ci_atc_check=>ty_findings.
 
-    METHODS has_multiple_conditions
+    METHODS has_and_condition
       IMPORTING !statement    TYPE if_ci_atc_source_code_provider=>ty_statement
       RETURNING VALUE(result) TYPE abap_bool.
 
@@ -131,16 +131,21 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
           " Push a new entry for this IF block onto the stack.
           DATA(entry) = VALUE ty_stack_entry( if_stmt_index = idx
                                               if_stmt       = <stmt> ).
-          IF has_multiple_conditions( <stmt> ) = abap_false.
-            " No null check on root: a compilable IF with a simple condition always
-            " has a subject token at position 2 (e.g. TYPE in: IF TYPE = 'A').
+          IF has_and_condition( <stmt> ) = abap_false.
             DATA(root) = get_condition_root( <stmt> ).
-            INSERT VALUE #( stmt_index     = idx
-                            stmt           = <stmt>
-                            condition_root = root
-                            when_value     = get_when_value( <stmt> ) ) INTO TABLE entry-branches.
+            IF root IS NOT INITIAL.
+              INSERT VALUE #( stmt_index     = idx
+                              stmt           = <stmt>
+                              condition_root = root
+                              when_value     = get_when_value( <stmt> ) ) INTO TABLE entry-branches.
+            ELSE.
+              " OR chain with different variables — cannot map to a single WHEN clause.
+              INSERT VALUE #( stmt_index = idx
+                              stmt       = <stmt>
+                              is_else    = abap_true ) INTO TABLE entry-branches.
+            ENDIF.
           ELSE.
-            " AND/OR conditions cannot be expressed as a single WHEN clause.
+            " AND conditions cannot be expressed as a WHEN clause.
             INSERT VALUE #( stmt_index = idx
                             stmt       = <stmt>
                             is_else    = abap_true ) INTO TABLE entry-branches.
@@ -150,15 +155,21 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
         WHEN 'ELSEIF'.
           IF stack IS NOT INITIAL.
             ASSIGN stack[ lines( stack ) ] TO FIELD-SYMBOL(<top>).
-            IF has_multiple_conditions( <stmt> ) = abap_false.
-              " Same guarantee as for IF: compilable simple ELSEIF always has token[2].
+            IF has_and_condition( <stmt> ) = abap_false.
               DATA(elseif_root) = get_condition_root( <stmt> ).
-              INSERT VALUE #( stmt_index     = idx
-                              stmt           = <stmt>
-                              condition_root = elseif_root
-                              when_value     = get_when_value( <stmt> ) ) INTO TABLE <top>-branches.
+              IF elseif_root IS NOT INITIAL.
+                INSERT VALUE #( stmt_index     = idx
+                                stmt           = <stmt>
+                                condition_root = elseif_root
+                                when_value     = get_when_value( <stmt> ) ) INTO TABLE <top>-branches.
+              ELSE.
+                " OR chain with different variables — cannot map to a single WHEN clause.
+                INSERT VALUE #( stmt_index = idx
+                                stmt       = <stmt>
+                                is_else    = abap_true ) INTO TABLE <top>-branches.
+              ENDIF.
             ELSE.
-              " AND/OR conditions cannot be expressed as a single WHEN clause.
+              " AND conditions cannot be expressed as a WHEN clause.
               INSERT VALUE #( stmt_index = idx
                               stmt       = <stmt>
                               is_else    = abap_true ) INTO TABLE <top>-branches.
@@ -193,8 +204,8 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
               " All non-else branches must share the same variable;
               " a mixed chain cannot be cleanly expressed as CASE.
               IF count >= threshold AND count = total_non_else.
-                " Skip the finding entirely when any IF/ELSEIF branch has AND/OR conditions.
-                " Such chains cannot be cleanly expressed as a CASE statement.
+                " Skip the finding when any IF/ELSEIF branch uses AND or a mixed OR
+                " condition — such branches can't map to a WHEN clause.
                 DATA has_complex_branch TYPE abap_bool.
                 LOOP AT popped-branches ASSIGNING FIELD-SYMBOL(<b>) WHERE is_else = abap_true.
                   IF <b>-stmt-keyword = 'IF' OR <b>-stmt-keyword = 'ELSEIF'.
@@ -233,25 +244,34 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
     ENDLOOP.
   ENDMETHOD.
 
-  METHOD has_multiple_conditions.
-    " AND / OR tokens mean the condition spans multiple sub-expressions and
-    " cannot be converted to a single WHEN clause.
-    " TODO: variable is assigned but never used (ABAP cleaner)
-    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<token>)
-        WHERE lexeme = 'AND' OR lexeme = 'OR'.
+  METHOD has_and_condition.
+    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<token>) WHERE lexeme = 'AND'.
       result = abap_true.
       RETURN.
     ENDLOOP.
   ENDMETHOD.
 
   METHOD get_condition_root.
-    " Token layout for a simple condition: [1]=IF/ELSEIF  [2]=<variable>  [3]=operator  [4]=value
+    " Token layout: [1]=IF/ELSEIF  [2]=<variable>  [3]=operator  [4]=value  ([5]=OR [6]=var ...)*
+    " For OR chains all sub-conditions must test the same variable; returns empty if they differ.
     result = VALUE #( statement-tokens[ 2 ]-lexeme OPTIONAL ).
+    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<t>) WHERE lexeme = 'OR'.
+      DATA(next_var) = VALUE #( statement-tokens[ sy-tabix + 1 ]-lexeme OPTIONAL ).
+      IF next_var <> result.
+        CLEAR result.
+        RETURN.
+      ENDIF.
+    ENDLOOP.
   ENDMETHOD.
 
   METHOD get_when_value.
-    " Token layout for a simple condition: [1]=IF/ELSEIF  [2]=<variable>  [3]=operator  [4]=value
+    " Simple:   [1]=kw [2]=var [3]=op [4]=value → 'value'
+    " OR chain: repeat [OR][var][op][value] → 'val1 OR val2 OR ...'
     result = VALUE #( statement-tokens[ 4 ]-lexeme OPTIONAL ).
+    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<t>) WHERE lexeme = 'OR'.
+      DATA(next_val) = VALUE #( statement-tokens[ sy-tabix + 3 ]-lexeme OPTIONAL ).
+      result = |{ result } OR { next_val }|.
+    ENDLOOP.
   ENDMETHOD.
 
   METHOD get_dominant_root.
@@ -299,7 +319,7 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
     " Derive the indentation step from the gap between the IF keyword column and
     " the first statement inside the IF body.
     TRY.
-        DATA(if_col)   = procedure-statements[ if_stmt_index ]-tokens[ 1 ]-position-column. "#EC SCOPE_OF_VAR
+        DATA(if_col)   = procedure-statements[ if_stmt_index ]-tokens[ 1 ]-position-column. "#EC CI_SCOPE_OF_VAR
         DATA(next_col) = procedure-statements[ if_stmt_index + 1 ]-tokens[ 1 ]-position-column.
         IF next_col > if_col.
           indent_step = next_col - if_col.

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
@@ -1,7 +1,6 @@
 CLASS /cc4a/prefer_case_to_elseif DEFINITION
-  PUBLIC
-  FINAL
-  CREATE PUBLIC .
+  PUBLIC FINAL
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
     INTERFACES if_ci_atc_check.
@@ -10,61 +9,90 @@ CLASS /cc4a/prefer_case_to_elseif DEFINITION
       BEGIN OF finding_codes,
         prefer_case TYPE if_ci_atc_check=>ty_finding_code VALUE 'PREF_CASE',
       END OF finding_codes.
+    CONSTANTS:
+      BEGIN OF quickfix_codes,
+        to_case TYPE cl_ci_atc_quickfixes=>ty_quickfix_code VALUE 'PREFTOCASE',
+      END OF quickfix_codes.
 
     METHODS constructor.
 
   PROTECTED SECTION.
+
   PRIVATE SECTION.
     CONSTANTS pseudo_comment TYPE string VALUE 'PREFER_CASE'.
-    CONSTANTS threshold       TYPE i      VALUE 5.
+    " Minimum number of branches sharing the same condition root to trigger a finding.
+    CONSTANTS threshold      TYPE i      VALUE 5.
 
+    " Represents one IF / ELSEIF / ELSE branch within an IF block.
+    " condition_root holds the left-hand side variable (e.g. TYPE in IF TYPE = 'A').
+    " is_else = true for branches that cannot map to a simple WHEN clause:
+    "   ELSE keyword, or IF/ELSEIF conditions joined by AND / OR.
+    TYPES:
+      BEGIN OF ty_branch,
+        stmt_index     TYPE i,
+        stmt           TYPE if_ci_atc_source_code_provider=>ty_statement,
+        condition_root TYPE string,
+        when_value     TYPE string,
+        is_else        TYPE abap_bool,
+      END OF ty_branch.
+    TYPES ty_branches TYPE STANDARD TABLE OF ty_branch WITH EMPTY KEY.
+
+    " One entry per open IF on the nesting stack.
     TYPES:
       BEGIN OF ty_stack_entry,
         if_stmt_index TYPE i,
         if_stmt       TYPE if_ci_atc_source_code_provider=>ty_statement,
+        branches      TYPE ty_branches,
       END OF ty_stack_entry.
-
-    TYPES:
-      BEGIN OF ty_chain,
-        if_stmt_index  TYPE i,
-        if_stmt        TYPE if_ci_atc_source_code_provider=>ty_statement,
-        condition_root TYPE string,
-        count          TYPE i,
-      END OF ty_chain.
 
     DATA code_provider     TYPE REF TO if_ci_atc_source_code_provider.
     DATA assistant_factory TYPE REF TO cl_ci_atc_assistant_factory.
     DATA meta_data         TYPE REF TO /cc4a/if_check_meta_data.
 
     METHODS analyze_procedure
-      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
-      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+      IMPORTING !procedure    TYPE if_ci_atc_source_code_provider=>ty_procedure
+      RETURNING VALUE(result) TYPE if_ci_atc_check=>ty_findings.
 
     METHODS has_multiple_conditions
-      IMPORTING statement     TYPE if_ci_atc_source_code_provider=>ty_statement
+      IMPORTING !statement    TYPE if_ci_atc_source_code_provider=>ty_statement
       RETURNING VALUE(result) TYPE abap_bool.
 
     METHODS get_condition_root
-      IMPORTING statement   TYPE if_ci_atc_source_code_provider=>ty_statement
-      RETURNING VALUE(root) TYPE string.
+      IMPORTING !statement    TYPE if_ci_atc_source_code_provider=>ty_statement
+      RETURNING VALUE(result) TYPE string.
+
+    METHODS get_when_value
+      IMPORTING !statement    TYPE if_ci_atc_source_code_provider=>ty_statement
+      RETURNING VALUE(result) TYPE string.
+
+    METHODS get_dominant_root
+      IMPORTING branches      TYPE ty_branches
+      RETURNING VALUE(result) TYPE string.
+
+    METHODS create_quickfix_code
+      IMPORTING !procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+                if_stmt_index    TYPE i
+                endif_stmt_index TYPE i
+                dominant_root    TYPE string
+                branches         TYPE ty_branches
+      RETURNING VALUE(result)    TYPE if_ci_atc_quickfix=>ty_code.
+
 ENDCLASS.
-
-
 
 CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
 
-
   METHOD constructor.
     meta_data = /cc4a/check_meta_data=>create(
-      VALUE #( checked_types     = /cc4a/check_meta_data=>checked_types-abap_programs
-               description       = 'Prefer CASE to ELSE IF'(des)
-               remote_enablement = /cc4a/check_meta_data=>remote_enablement-unconditional
-               finding_codes     = VALUE #(
-                 ( code           = finding_codes-prefer_case
-                   pseudo_comment = pseudo_comment
-                   text           = 'Prefer CASE to ELSE IF for multiple alternative conditions!'(pce) ) ) ) ).
+        VALUE #( checked_types     = /cc4a/check_meta_data=>checked_types-abap_programs
+                 description       = 'Prefer CASE to ELSE IF'(des)
+                 remote_enablement = /cc4a/check_meta_data=>remote_enablement-unconditional
+                 finding_codes     = VALUE #(
+                     ( code           = finding_codes-prefer_case
+                       pseudo_comment = pseudo_comment
+                       text           = 'Prefer CASE to ELSE IF for multiple alternative conditions!'(pce) ) )
+                 quickfix_codes    = VALUE #( ( code       = quickfix_codes-to_case
+                                                short_text = 'Replace IF/ELSEIF chain with CASE statement'(qtc) ) ) ) ).
   ENDMETHOD.
-
 
   METHOD if_ci_atc_check~run.
     code_provider = data_provider->get_code_provider( ).
@@ -74,28 +102,25 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
     ENDLOOP.
   ENDMETHOD.
 
-
   METHOD if_ci_atc_check~get_meta_data.
     meta_data = me->meta_data.
   ENDMETHOD.
-
 
   METHOD if_ci_atc_check~set_assistant_factory.
     assistant_factory = factory.
   ENDMETHOD.
 
-
   METHOD if_ci_atc_check~set_attributes ##NEEDED.
   ENDMETHOD.
-
 
   METHOD if_ci_atc_check~verify_prerequisites.
   ENDMETHOD.
 
-
   METHOD analyze_procedure.
-    DATA stack  TYPE STANDARD TABLE OF ty_stack_entry WITH EMPTY KEY.
-    DATA chains TYPE STANDARD TABLE OF ty_chain       WITH EMPTY KEY.
+    " Stack tracks open IF blocks to handle nested IFs correctly.
+    " Each entry accumulates the branches of one IF block until ENDIF closes it.
+
+    DATA stack TYPE STANDARD TABLE OF ty_stack_entry WITH EMPTY KEY.
 
     LOOP AT procedure-statements ASSIGNING FIELD-SYMBOL(<stmt>).
       DATA(idx) = sy-tabix.
@@ -103,34 +128,50 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
       CASE <stmt>-keyword.
 
         WHEN 'IF'.
-          INSERT VALUE #( if_stmt_index = idx if_stmt = <stmt> ) INTO TABLE stack.
+          " Push a new entry for this IF block onto the stack.
+          DATA(entry) = VALUE ty_stack_entry( if_stmt_index = idx
+                                              if_stmt       = <stmt> ).
           IF has_multiple_conditions( <stmt> ) = abap_false.
+            " No null check on root: a compilable IF with a simple condition always
+            " has a subject token at position 2 (e.g. TYPE in: IF TYPE = 'A').
             DATA(root) = get_condition_root( <stmt> ).
-            IF root IS NOT INITIAL.
-              INSERT VALUE #( if_stmt_index  = idx
-                              if_stmt        = <stmt>
-                              condition_root = root
-                              count          = 1 ) INTO TABLE chains.
-            ENDIF.
+            INSERT VALUE #( stmt_index     = idx
+                            stmt           = <stmt>
+                            condition_root = root
+                            when_value     = get_when_value( <stmt> ) ) INTO TABLE entry-branches.
+          ELSE.
+            " AND/OR conditions cannot be expressed as a single WHEN clause.
+            INSERT VALUE #( stmt_index = idx
+                            stmt       = <stmt>
+                            is_else    = abap_true ) INTO TABLE entry-branches.
           ENDIF.
+          INSERT entry INTO TABLE stack.
 
         WHEN 'ELSEIF'.
           IF stack IS NOT INITIAL.
-            DATA(top) = stack[ lines( stack ) ].
+            ASSIGN stack[ lines( stack ) ] TO FIELD-SYMBOL(<top>).
             IF has_multiple_conditions( <stmt> ) = abap_false.
+              " Same guarantee as for IF: compilable simple ELSEIF always has token[2].
               DATA(elseif_root) = get_condition_root( <stmt> ).
-              IF elseif_root IS NOT INITIAL.
-                TRY.
-                    chains[ if_stmt_index  = top-if_stmt_index
-                            condition_root = elseif_root ]-count += 1.
-                  CATCH cx_sy_itab_line_not_found.
-                    INSERT VALUE #( if_stmt_index  = top-if_stmt_index
-                                    if_stmt        = top-if_stmt
-                                    condition_root = elseif_root
-                                    count          = 1 ) INTO TABLE chains.
-                ENDTRY.
-              ENDIF.
+              INSERT VALUE #( stmt_index     = idx
+                              stmt           = <stmt>
+                              condition_root = elseif_root
+                              when_value     = get_when_value( <stmt> ) ) INTO TABLE <top>-branches.
+            ELSE.
+              " AND/OR conditions cannot be expressed as a single WHEN clause.
+              INSERT VALUE #( stmt_index = idx
+                              stmt       = <stmt>
+                              is_else    = abap_true ) INTO TABLE <top>-branches.
             ENDIF.
+          ENDIF.
+
+        WHEN 'ELSE'.
+          " ELSE has no condition; its body becomes WHEN OTHERS in the quickfix.
+          IF stack IS NOT INITIAL.
+            ASSIGN stack[ lines( stack ) ] TO FIELD-SYMBOL(<top_else>).
+            INSERT VALUE #( stmt_index = idx
+                            stmt       = <stmt>
+                            is_else    = abap_true ) INTO TABLE <top_else>-branches.
           ENDIF.
 
         WHEN 'ENDIF'.
@@ -138,29 +179,64 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
             DATA(popped) = stack[ lines( stack ) ].
             DELETE stack INDEX lines( stack ).
 
-            LOOP AT chains ASSIGNING FIELD-SYMBOL(<chain>) ##PRIMKEY[IF_STMT_INDEX]
-                WHERE if_stmt_index = popped-if_stmt_index
-                  AND count >= threshold.
-              INSERT VALUE #(
-                code               = finding_codes-prefer_case
-                location           = code_provider->get_statement_location( <chain>-if_stmt )
-                checksum           = code_provider->get_statement_checksum( <chain>-if_stmt )
-                has_pseudo_comment = meta_data->has_valid_pseudo_comment(
-                  statement    = <chain>-if_stmt
-                  finding_code = finding_codes-prefer_case )
-              ) INTO TABLE findings.
-              EXIT.
-            ENDLOOP.
+            " Find the condition root that appears most often across non-else branches.
+            DATA(dom_root) = get_dominant_root( popped-branches ).
+            IF dom_root IS NOT INITIAL.
+              DATA(count) = REDUCE i( INIT n = 0
+                                      FOR b IN popped-branches
+                                      WHERE ( condition_root = dom_root )
+                                      NEXT n = n + 1 ).
+              DATA(total_non_else) = REDUCE i( INIT n = 0
+                                               FOR b IN popped-branches
+                                               WHERE ( is_else = abap_false )
+                                               NEXT n = n + 1 ).
+              " All non-else branches must share the same variable;
+              " a mixed chain cannot be cleanly expressed as CASE.
+              IF count >= threshold AND count = total_non_else.
+                " Skip the finding entirely when any IF/ELSEIF branch has AND/OR conditions.
+                " Such chains cannot be cleanly expressed as a CASE statement.
+                DATA has_complex_branch TYPE abap_bool.
+                LOOP AT popped-branches ASSIGNING FIELD-SYMBOL(<b>) WHERE is_else = abap_true.
+                  IF <b>-stmt-keyword = 'IF' OR <b>-stmt-keyword = 'ELSEIF'.
+                    has_complex_branch = abap_true.
+                    EXIT.
+                  ENDIF.
+                ENDLOOP.
 
-            DELETE chains WHERE if_stmt_index = popped-if_stmt_index.
+                IF has_complex_branch = abap_false.
+                  DATA(available_quickfixes) = assistant_factory->create_quickfixes( ).
+                  available_quickfixes->create_quickfix( quickfix_codes-to_case )->replace(
+                      context = assistant_factory->create_quickfix_context(
+                                    VALUE #( procedure_id = procedure-id
+                                             statements   = VALUE #( from = popped-if_stmt_index
+                                                                     to   = idx ) ) )
+                      code    = create_quickfix_code( procedure        = procedure
+                                                      if_stmt_index    = popped-if_stmt_index
+                                                      endif_stmt_index = idx
+                                                      dominant_root    = dom_root
+                                                      branches         = popped-branches ) ).
+                  INSERT VALUE #(
+                      code               = finding_codes-prefer_case
+                      location           = code_provider->get_statement_location( popped-if_stmt )
+                      checksum           = code_provider->get_statement_checksum( popped-if_stmt )
+                      has_pseudo_comment = meta_data->has_valid_pseudo_comment( statement    = popped-if_stmt
+                                                                                finding_code = finding_codes-prefer_case )
+                      details            = assistant_factory->create_finding_details( )->attach_quickfixes(
+                                               available_quickfixes ) )
+                  INTO TABLE result.
+                ENDIF.
+              ENDIF.
+            ENDIF.
           ENDIF.
 
       ENDCASE.
     ENDLOOP.
   ENDMETHOD.
 
-
   METHOD has_multiple_conditions.
+    " AND / OR tokens mean the condition spans multiple sub-expressions and
+    " cannot be converted to a single WHEN clause.
+    " TODO: variable is assigned but never used (ABAP cleaner)
     LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<token>)
         WHERE lexeme = 'AND' OR lexeme = 'OR'.
       result = abap_true.
@@ -168,13 +244,127 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
     ENDLOOP.
   ENDMETHOD.
 
-
   METHOD get_condition_root.
-    TRY.
-        root = statement-tokens[ 2 ]-lexeme.
-      CATCH cx_sy_itab_line_not_found.
-    ENDTRY.
+    " Token layout for a simple condition: [1]=IF/ELSEIF  [2]=<variable>  [3]=operator  [4]=value
+    result = VALUE #( statement-tokens[ 2 ]-lexeme OPTIONAL ).
   ENDMETHOD.
 
+  METHOD get_when_value.
+    " Token layout for a simple condition: [1]=IF/ELSEIF  [2]=<variable>  [3]=operator  [4]=value
+    result = VALUE #( statement-tokens[ 4 ]-lexeme OPTIONAL ).
+  ENDMETHOD.
+
+  METHOD get_dominant_root.
+    " Count how many branches share each condition root (left-hand side variable).
+    " Returns the root with the highest count; empty if all branches are is_else.
+    TYPES: BEGIN OF ty_root_count,
+             root  TYPE string,
+             count TYPE i,
+           END OF ty_root_count.
+
+    DATA counts TYPE STANDARD TABLE OF ty_root_count WITH EMPTY KEY.
+
+    LOOP AT branches ASSIGNING FIELD-SYMBOL(<branch>) WHERE is_else = abap_false AND condition_root IS NOT INITIAL.
+      TRY.
+          counts[ root = <branch>-condition_root ]-count += 1.
+        CATCH cx_sy_itab_line_not_found.
+          INSERT VALUE #( root  = <branch>-condition_root
+                          count = 1 ) INTO TABLE counts.
+      ENDTRY.
+    ENDLOOP.
+
+    DATA(max_count) = 0.
+    LOOP AT counts ASSIGNING FIELD-SYMBOL(<cnt>).
+      IF <cnt>-count > max_count.
+        max_count = <cnt>-count.
+        result = <cnt>-root.
+      ENDIF.
+    ENDLOOP.
+  ENDMETHOD.
+
+  METHOD create_quickfix_code.
+    DATA indent_step        TYPE i VALUE 2.
+    DATA br                 TYPE ty_branch.
+    DATA in_dominant_branch TYPE abap_bool.
+    DATA branch_body        TYPE if_ci_atc_quickfix=>ty_code.
+    DATA in_else_branch     TYPE abap_bool.
+    " Accumulates body lines for non-dominant branches; emitted as WHEN OTHERS at
+    " the end because ABAP requires WHEN OTHERS to be the last clause in a CASE.
+    DATA else_body          TYPE if_ci_atc_quickfix=>ty_code.
+    DATA has_else           TYPE abap_bool.
+    DATA flat               TYPE string.
+
+    DATA(analyzer) = /cc4a/abap_analyzer=>create( ).
+
+    " Derive the indentation step from the gap between the IF keyword column and
+    " the first statement inside the IF body.
+    TRY.
+        DATA(if_col)   = procedure-statements[ if_stmt_index ]-tokens[ 1 ]-position-column. "#EC SCOPE_OF_VAR
+        DATA(next_col) = procedure-statements[ if_stmt_index + 1 ]-tokens[ 1 ]-position-column.
+        IF next_col > if_col.
+          indent_step = next_col - if_col.
+        ENDIF.
+      CATCH cx_sy_itab_line_not_found.
+    ENDTRY.
+
+    " The quickfix framework prepends if_col spaces to the first line only.
+    " All subsequent lines need their absolute column written explicitly here.
+    DATA(case_indent) = repeat( val = ` `
+                                occ = if_col ).          " ENDCASE level
+    DATA(when_indent) = repeat( val = ` `
+                                occ = if_col + indent_step ).
+    DATA(body_indent) = repeat( val = ` `
+                                occ = if_col + indent_step * 2 ).
+
+    " First line: framework adds if_col, so no explicit prefix needed here.
+    INSERT |CASE { dominant_root } .| INTO TABLE result.
+
+    LOOP AT procedure-statements ASSIGNING FIELD-SYMBOL(<stmt>) FROM if_stmt_index TO endif_stmt_index.
+      CASE <stmt>-keyword.
+        WHEN 'IF' OR 'ELSEIF'.
+          READ TABLE branches INTO br WITH KEY stmt_index = sy-tabix.
+          IF sy-subrc = 0 AND br-is_else = abap_false AND br-condition_root = dominant_root.
+            " Flush any accumulated body before starting the next WHEN clause.
+            IF in_dominant_branch = abap_true.
+              INSERT LINES OF branch_body INTO TABLE result.
+              CLEAR branch_body.
+            ENDIF.
+            INSERT |{ when_indent }WHEN { br-when_value } .| INTO TABLE result.
+            in_dominant_branch = abap_true.
+          ENDIF.
+
+        WHEN 'ELSE'.
+          IF in_dominant_branch = abap_true.
+            INSERT LINES OF branch_body INTO TABLE result.
+            CLEAR branch_body.
+            in_dominant_branch = abap_false.
+          ENDIF.
+          in_else_branch = abap_true.
+          has_else = abap_true.
+
+        WHEN 'ENDIF'.
+          IF in_dominant_branch = abap_true.
+            INSERT LINES OF branch_body INTO TABLE result.
+            CLEAR branch_body.
+          ENDIF.
+          IF in_else_branch = abap_true.
+            INSERT LINES OF branch_body INTO TABLE else_body.
+            CLEAR branch_body.
+          ENDIF.
+          " Emit WHEN OTHERS last — ABAP syntax requires it to be the final clause.
+          IF has_else = abap_true.
+            INSERT |{ when_indent }WHEN OTHERS .| INTO TABLE result.
+            INSERT LINES OF else_body INTO TABLE result.
+          ENDIF.
+          INSERT |{ case_indent }ENDCASE .| INTO TABLE result.
+
+        WHEN OTHERS.
+          IF in_dominant_branch = abap_true OR in_else_branch = abap_true.
+            flat = |{ body_indent }{ analyzer->flatten_tokens( <stmt>-tokens ) }.|.
+            INSERT flat INTO TABLE branch_body.
+          ENDIF.
+      ENDCASE.
+    ENDLOOP.
+  ENDMETHOD.
 
 ENDCLASS.

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
@@ -1,0 +1,180 @@
+CLASS /cc4a/prefer_case_to_elseif DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+    INTERFACES if_ci_atc_check.
+
+    CONSTANTS:
+      BEGIN OF finding_codes,
+        prefer_case TYPE if_ci_atc_check=>ty_finding_code VALUE 'PREF_CASE',
+      END OF finding_codes.
+
+    METHODS constructor.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    CONSTANTS pseudo_comment TYPE string VALUE 'PREFER_CASE'.
+    CONSTANTS threshold       TYPE i      VALUE 5.
+
+    TYPES:
+      BEGIN OF ty_stack_entry,
+        if_stmt_index TYPE i,
+        if_stmt       TYPE if_ci_atc_source_code_provider=>ty_statement,
+      END OF ty_stack_entry.
+
+    TYPES:
+      BEGIN OF ty_chain,
+        if_stmt_index  TYPE i,
+        if_stmt        TYPE if_ci_atc_source_code_provider=>ty_statement,
+        condition_root TYPE string,
+        count          TYPE i,
+      END OF ty_chain.
+
+    DATA code_provider     TYPE REF TO if_ci_atc_source_code_provider.
+    DATA assistant_factory TYPE REF TO cl_ci_atc_assistant_factory.
+    DATA meta_data         TYPE REF TO /cc4a/if_check_meta_data.
+
+    METHODS analyze_procedure
+      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+
+    METHODS has_multiple_conditions
+      IMPORTING statement     TYPE if_ci_atc_source_code_provider=>ty_statement
+      RETURNING VALUE(result) TYPE abap_bool.
+
+    METHODS get_condition_root
+      IMPORTING statement   TYPE if_ci_atc_source_code_provider=>ty_statement
+      RETURNING VALUE(root) TYPE string.
+ENDCLASS.
+
+
+
+CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
+
+
+  METHOD constructor.
+    meta_data = /cc4a/check_meta_data=>create(
+      VALUE #( checked_types     = /cc4a/check_meta_data=>checked_types-abap_programs
+               description       = 'Prefer CASE to ELSE IF'(des)
+               remote_enablement = /cc4a/check_meta_data=>remote_enablement-unconditional
+               finding_codes     = VALUE #(
+                 ( code           = finding_codes-prefer_case
+                   pseudo_comment = pseudo_comment
+                   text           = 'Prefer CASE to ELSE IF for multiple alternative conditions!'(pce) ) ) ) ).
+  ENDMETHOD.
+
+
+  METHOD if_ci_atc_check~run.
+    code_provider = data_provider->get_code_provider( ).
+    DATA(procedures) = code_provider->get_procedures( code_provider->object_to_comp_unit( object ) ).
+    LOOP AT procedures->* ASSIGNING FIELD-SYMBOL(<procedure>).
+      INSERT LINES OF analyze_procedure( <procedure> ) INTO TABLE findings.
+    ENDLOOP.
+  ENDMETHOD.
+
+
+  METHOD if_ci_atc_check~get_meta_data.
+    meta_data = me->meta_data.
+  ENDMETHOD.
+
+
+  METHOD if_ci_atc_check~set_assistant_factory.
+    assistant_factory = factory.
+  ENDMETHOD.
+
+
+  METHOD if_ci_atc_check~set_attributes ##NEEDED.
+  ENDMETHOD.
+
+
+  METHOD if_ci_atc_check~verify_prerequisites.
+  ENDMETHOD.
+
+
+  METHOD analyze_procedure.
+    DATA stack  TYPE STANDARD TABLE OF ty_stack_entry WITH EMPTY KEY.
+    DATA chains TYPE STANDARD TABLE OF ty_chain       WITH EMPTY KEY.
+
+    LOOP AT procedure-statements ASSIGNING FIELD-SYMBOL(<stmt>).
+      DATA(idx) = sy-tabix.
+
+      CASE <stmt>-keyword.
+
+        WHEN 'IF'.
+          INSERT VALUE #( if_stmt_index = idx if_stmt = <stmt> ) INTO TABLE stack.
+          IF has_multiple_conditions( <stmt> ) = abap_false.
+            DATA(root) = get_condition_root( <stmt> ).
+            IF root IS NOT INITIAL.
+              INSERT VALUE #( if_stmt_index  = idx
+                              if_stmt        = <stmt>
+                              condition_root = root
+                              count          = 1 ) INTO TABLE chains.
+            ENDIF.
+          ENDIF.
+
+        WHEN 'ELSEIF'.
+          IF stack IS NOT INITIAL.
+            DATA(top) = stack[ lines( stack ) ].
+            IF has_multiple_conditions( <stmt> ) = abap_false.
+              DATA(elseif_root) = get_condition_root( <stmt> ).
+              IF elseif_root IS NOT INITIAL.
+                TRY.
+                    chains[ if_stmt_index  = top-if_stmt_index
+                            condition_root = elseif_root ]-count += 1.
+                  CATCH cx_sy_itab_line_not_found.
+                    INSERT VALUE #( if_stmt_index  = top-if_stmt_index
+                                    if_stmt        = top-if_stmt
+                                    condition_root = elseif_root
+                                    count          = 1 ) INTO TABLE chains.
+                ENDTRY.
+              ENDIF.
+            ENDIF.
+          ENDIF.
+
+        WHEN 'ENDIF'.
+          IF stack IS NOT INITIAL.
+            DATA(popped) = stack[ lines( stack ) ].
+            DELETE stack INDEX lines( stack ).
+
+            LOOP AT chains ASSIGNING FIELD-SYMBOL(<chain>) ##PRIMKEY[IF_STMT_INDEX]
+                WHERE if_stmt_index = popped-if_stmt_index
+                  AND count >= threshold.
+              INSERT VALUE #(
+                code               = finding_codes-prefer_case
+                location           = code_provider->get_statement_location( <chain>-if_stmt )
+                checksum           = code_provider->get_statement_checksum( <chain>-if_stmt )
+                has_pseudo_comment = meta_data->has_valid_pseudo_comment(
+                  statement    = <chain>-if_stmt
+                  finding_code = finding_codes-prefer_case )
+              ) INTO TABLE findings.
+              EXIT.
+            ENDLOOP.
+
+            DELETE chains WHERE if_stmt_index = popped-if_stmt_index.
+          ENDIF.
+
+      ENDCASE.
+    ENDLOOP.
+  ENDMETHOD.
+
+
+  METHOD has_multiple_conditions.
+    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<token>)
+        WHERE lexeme = 'AND' OR lexeme = 'OR'.
+      result = abap_true.
+      RETURN.
+    ENDLOOP.
+  ENDMETHOD.
+
+
+  METHOD get_condition_root.
+    TRY.
+        root = statement-tokens[ 2 ]-lexeme.
+      CATCH cx_sy_itab_line_not_found.
+    ENDTRY.
+  ENDMETHOD.
+
+
+ENDCLASS.

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
@@ -1,0 +1,52 @@
+CLASS test DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+    CONSTANTS test_class            TYPE c LENGTH 30 VALUE '/CC4A/TEST_PREFER_CASE_ELSEIF'.
+    CONSTANTS test_class_no_findings TYPE c LENGTH 30 VALUE '/CC4A/TEST_PREFER_CASE_ELSEIF2'.
+    CONSTANTS:
+      BEGIN OF test_class_methods,
+        with_elseif_chain   TYPE c LENGTH 30 VALUE 'WITH_ELSEIF_CHAIN',
+        with_pseudo_comment TYPE c LENGTH 30 VALUE 'WITH_PSEUDO_COMMENT',
+      END OF test_class_methods.
+
+    METHODS execute_test_class FOR TESTING RAISING cx_static_check.
+    METHODS no_findings        FOR TESTING RAISING cx_static_check.
+ENDCLASS.
+
+CLASS test IMPLEMENTATION.
+  METHOD execute_test_class.
+
+    DATA(with_elseif_chain_finding) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_elseif_chain ) )
+          position = VALUE #( line = 3 column = 4 ) ).
+
+    DATA(with_pseudo_comment_finding) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_pseudo_comment ) )
+          position = VALUE #( line = 3 column = 4 ) ).
+
+    cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
+              check             = NEW /cc4a/prefer_case_to_elseif( )
+              object            = VALUE #( type = 'CLAS' name = test_class )
+              expected_findings = VALUE #( code = /cc4a/prefer_case_to_elseif=>finding_codes-prefer_case
+                                           ( location = with_elseif_chain_finding )
+                                           ( location = with_pseudo_comment_finding ) )
+              asserter_config   = VALUE #( quickfixes = abap_false ) ).
+
+  ENDMETHOD.
+
+  METHOD no_findings.
+
+    cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
+              check             = NEW /cc4a/prefer_case_to_elseif( )
+              object            = VALUE #( type = 'CLAS' name = test_class_no_findings )
+              expected_findings = VALUE #( )
+              asserter_config   = VALUE #( quickfixes = abap_false ) ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
@@ -7,8 +7,11 @@ CLASS test DEFINITION FINAL FOR TESTING
     CONSTANTS test_class_no_findings TYPE c LENGTH 30 VALUE '/CC4A/TEST_PREFER_CASE_ELSEIF2'.
     CONSTANTS:
       BEGIN OF test_class_methods,
-        with_elseif_chain   TYPE c LENGTH 30 VALUE 'WITH_ELSEIF_CHAIN',
-        with_pseudo_comment TYPE c LENGTH 30 VALUE 'WITH_PSEUDO_COMMENT',
+        with_elseif_chain     TYPE c LENGTH 30 VALUE 'WITH_ELSEIF_CHAIN',
+        with_pseudo_comment   TYPE c LENGTH 30 VALUE 'WITH_PSEUDO_COMMENT',
+        with_nested_if        TYPE c LENGTH 30 VALUE 'WITH_NESTED_IF',
+        with_double_nested_if TYPE c LENGTH 30 VALUE 'WITH_DOUBLE_NESTED_IF',
+        with_else_branch      TYPE c LENGTH 30 VALUE 'WITH_ELSE_BRANCH',
       END OF test_class_methods.
 
     METHODS execute_test_class FOR TESTING RAISING cx_static_check.
@@ -28,12 +31,134 @@ CLASS test IMPLEMENTATION.
             VALUE #( class = test_class method = test_class_methods-with_pseudo_comment ) )
           position = VALUE #( line = 3 column = 4 ) ).
 
+    DATA(with_nested_if_finding) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_nested_if ) )
+          position = VALUE #( line = 5 column = 6 ) ).
+
+    DATA(with_double_nested_finding_1) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_double_nested_if ) )
+          position = VALUE #( line = 6 column = 6 ) ).
+
+    DATA(with_double_nested_finding_2) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_double_nested_if ) )
+          position = VALUE #( line = 19 column = 6 ) ).
+
+    DATA(with_else_branch_finding) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_else_branch ) )
+          position = VALUE #( line = 3 column = 4 ) ).
+
     cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
               check             = NEW /cc4a/prefer_case_to_elseif( )
               object            = VALUE #( type = 'CLAS' name = test_class )
               expected_findings = VALUE #( code = /cc4a/prefer_case_to_elseif=>finding_codes-prefer_case
-                                           ( location = with_elseif_chain_finding )
-                                           ( location = with_pseudo_comment_finding ) )
+                                           ( location = with_elseif_chain_finding
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_elseif_chain_finding
+                                               code = VALUE #(
+                                               ( `CASE TYPE .` )
+                                               ( `      WHEN 'A' .` )
+                                               ( `        DATA(RESULT) = 1 .` )
+                                               ( `      WHEN 'B' .` )
+                                               ( `        RESULT = 2 .` )
+                                               ( `      WHEN 'C' .` )
+                                               ( `        RESULT = 3 .` )
+                                               ( `      WHEN 'D' .` )
+                                               ( `        RESULT = 4 .` )
+                                               ( `      WHEN 'E' .` )
+                                               ( `        RESULT = 5 .` )
+                                               ( `    ENDCASE .` ) ) ) ) )
+                                           ( location = with_pseudo_comment_finding
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_pseudo_comment_finding
+                                               code = VALUE #(
+                                               ( `CASE TYPE .` )
+                                               ( `      WHEN 'A' .` )
+                                               ( `        DATA(RESULT) = 1 .` )
+                                               ( `      WHEN 'B' .` )
+                                               ( `        RESULT = 2 .` )
+                                               ( `      WHEN 'C' .` )
+                                               ( `        RESULT = 3 .` )
+                                               ( `      WHEN 'D' .` )
+                                               ( `        RESULT = 4 .` )
+                                               ( `      WHEN 'E' .` )
+                                               ( `        RESULT = 5 .` )
+                                               ( `    ENDCASE .` ) ) ) ) )
+                                           ( location = with_nested_if_finding
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_nested_if_finding
+                                               code = VALUE #(
+                                               ( `CASE SUBTYPE .` )
+                                               ( `        WHEN 'X' .` )
+                                               ( `          DATA(RESULT) = 1 .` )
+                                               ( `        WHEN 'Y' .` )
+                                               ( `          RESULT = 2 .` )
+                                               ( `        WHEN 'Z' .` )
+                                               ( `          RESULT = 3 .` )
+                                               ( `        WHEN 'W' .` )
+                                               ( `          RESULT = 4 .` )
+                                               ( `        WHEN 'V' .` )
+                                               ( `          RESULT = 5 .` )
+                                               ( `      ENDCASE .` ) ) ) ) )
+                                           ( location = with_double_nested_finding_1
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_double_nested_finding_1
+                                               code = VALUE #(
+                                               ( `CASE SUBTYPE1 .` )
+                                               ( `        WHEN 'X' .` )
+                                               ( `          DATA(RESULT) = 1 .` )
+                                               ( `        WHEN 'Y' .` )
+                                               ( `          RESULT = 2 .` )
+                                               ( `        WHEN 'Z' .` )
+                                               ( `          RESULT = 3 .` )
+                                               ( `        WHEN 'W' .` )
+                                               ( `          RESULT = 4 .` )
+                                               ( `        WHEN 'V' .` )
+                                               ( `          RESULT = 5 .` )
+                                               ( `      ENDCASE .` ) ) ) ) )
+                                           ( location = with_double_nested_finding_2
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_double_nested_finding_2
+                                               code = VALUE #(
+                                               ( `CASE SUBTYPE2 .` )
+                                               ( `        WHEN 'P' .` )
+                                               ( `          RESULT = 10 .` )
+                                               ( `        WHEN 'Q' .` )
+                                               ( `          RESULT = 11 .` )
+                                               ( `        WHEN 'R' .` )
+                                               ( `          RESULT = 12 .` )
+                                               ( `        WHEN 'S' .` )
+                                               ( `          RESULT = 13 .` )
+                                               ( `        WHEN 'T' .` )
+                                               ( `          RESULT = 14 .` )
+                                               ( `      ENDCASE .` ) ) ) ) )
+                                           ( location = with_else_branch_finding
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_else_branch_finding
+                                               code = VALUE #(
+                                               ( `CASE TYPE .` )
+                                               ( `      WHEN 'A' .` )
+                                               ( `        DATA(RESULT) = 1 .` )
+                                               ( `      WHEN 'B' .` )
+                                               ( `        RESULT = 2 .` )
+                                               ( `      WHEN 'C' .` )
+                                               ( `        RESULT = 3 .` )
+                                               ( `      WHEN 'D' .` )
+                                               ( `        RESULT = 4 .` )
+                                               ( `      WHEN 'E' .` )
+                                               ( `        RESULT = 5 .` )
+                                               ( `      WHEN OTHERS .` )
+                                               ( `        RESULT = 0 .` )
+                                               ( `    ENDCASE .` ) ) ) ) ) )
               asserter_config   = VALUE #( quickfixes = abap_false ) ).
 
   ENDMETHOD.
@@ -49,4 +174,3 @@ CLASS test IMPLEMENTATION.
   ENDMETHOD.
 
 ENDCLASS.
-

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
@@ -7,11 +7,12 @@ CLASS test DEFINITION FINAL FOR TESTING
     CONSTANTS test_class_no_findings TYPE c LENGTH 30 VALUE '/CC4A/TEST_PREFER_CASE_ELSEIF2'.
     CONSTANTS:
       BEGIN OF test_class_methods,
-        with_elseif_chain     TYPE c LENGTH 30 VALUE 'WITH_ELSEIF_CHAIN',
-        with_pseudo_comment   TYPE c LENGTH 30 VALUE 'WITH_PSEUDO_COMMENT',
-        with_nested_if        TYPE c LENGTH 30 VALUE 'WITH_NESTED_IF',
-        with_double_nested_if TYPE c LENGTH 30 VALUE 'WITH_DOUBLE_NESTED_IF',
-        with_else_branch      TYPE c LENGTH 30 VALUE 'WITH_ELSE_BRANCH',
+        with_elseif_chain       TYPE c LENGTH 30 VALUE 'WITH_ELSEIF_CHAIN',
+        with_pseudo_comment     TYPE c LENGTH 30 VALUE 'WITH_PSEUDO_COMMENT',
+        with_nested_if          TYPE c LENGTH 30 VALUE 'WITH_NESTED_IF',
+        with_double_nested_if   TYPE c LENGTH 30 VALUE 'WITH_DOUBLE_NESTED_IF',
+        with_else_branch        TYPE c LENGTH 30 VALUE 'WITH_ELSE_BRANCH',
+        with_or_condition       TYPE c LENGTH 30 VALUE 'WITH_OR_CONDITION',
       END OF test_class_methods.
 
     METHODS execute_test_class FOR TESTING RAISING cx_static_check.
@@ -49,6 +50,11 @@ CLASS test IMPLEMENTATION.
     DATA(with_else_branch_finding) = VALUE if_ci_atc_check=>ty_location(
           object   = cl_ci_atc_unit_driver=>get_method_object(
             VALUE #( class = test_class method = test_class_methods-with_else_branch ) )
+          position = VALUE #( line = 3 column = 4 ) ).
+
+    DATA(with_or_condition_finding) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_or_condition ) )
           position = VALUE #( line = 3 column = 4 ) ).
 
     cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
@@ -158,6 +164,23 @@ CLASS test IMPLEMENTATION.
                                                ( `        RESULT = 5 .` )
                                                ( `      WHEN OTHERS .` )
                                                ( `        RESULT = 0 .` )
+                                               ( `    ENDCASE .` ) ) ) ) )
+                                           ( location = with_or_condition_finding
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_or_condition_finding
+                                               code = VALUE #(
+                                               ( `CASE TYPE .` )
+                                               ( `      WHEN 'A' OR 'B' .` )
+                                               ( `        DATA(RESULT) = 1 .` )
+                                               ( `      WHEN 'C' .` )
+                                               ( `        RESULT = 2 .` )
+                                               ( `      WHEN 'D' .` )
+                                               ( `        RESULT = 3 .` )
+                                               ( `      WHEN 'E' .` )
+                                               ( `        RESULT = 4 .` )
+                                               ( `      WHEN 'F' .` )
+                                               ( `        RESULT = 5 .` )
                                                ( `    ENDCASE .` ) ) ) ) ) )
               asserter_config   = VALUE #( quickfixes = abap_false ) ).
 

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.xml
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>/CC4A/PREFER_CASE_TO_ELSEIF</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Prefer CASE to ELSE IF</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.xml
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.xml
@@ -12,6 +12,26 @@
     <UNICODE>X</UNICODE>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>DES</KEY>
+     <ENTRY>Prefer CASE to ELSE IF</ENTRY>
+     <LENGTH>44</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>PCE</KEY>
+     <ENTRY>Prefer CASE to ELSE IF for multiple alternative conditions!</ENTRY>
+     <LENGTH>118</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>QTC</KEY>
+     <ENTRY>Replace IF/ELSEIF chain with CASE statement</ENTRY>
+     <LENGTH>86</LENGTH>
+    </item>
+   </TPOOL>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/src/checks/(cc4a)prefer_case_to_elseif.chko.json
+++ b/src/checks/(cc4a)prefer_case_to_elseif.chko.json
@@ -1,0 +1,10 @@
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "Prefer CASE to ELSE IF",
+    "originalLanguage": "en"
+  },
+  "category": "/CC4A/CODE_PAL",
+  "implementingClass": "/CC4A/PREFER_CASE_TO_ELSEIF",
+  "checkType": "remoteEnabled"
+}

--- a/src/core/(cc4a)code_pal_full.chkv.json
+++ b/src/core/(cc4a)code_pal_full.chkv.json
@@ -77,6 +77,9 @@
     },
     {
       "checkName": "/CC4A/VARIABLE_SCOPE"
+    },
+    {
+      "checkName": "/CC4A/PREFER_CASE_TO_ELSEIF"
     }
   ]
 }

--- a/src/core/(cc4a)code_pal_remote.chkv.json
+++ b/src/core/(cc4a)code_pal_remote.chkv.json
@@ -74,6 +74,9 @@
     },
     {
       "checkName": "/CC4A/VARIABLE_SCOPE"
+    },
+    {
+      "checkName": "/CC4A/PREFER_CASE_TO_ELSEIF"
     }
   ]
 }

--- a/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
@@ -8,6 +8,9 @@ CLASS /cc4a/test_prefer_case_elseif DEFINITION
   PRIVATE SECTION.
     METHODS with_elseif_chain.
     METHODS with_pseudo_comment.
+    METHODS with_nested_if.
+    METHODS with_double_nested_if.
+    METHODS with_else_branch.
 ENDCLASS.
 
 
@@ -26,6 +29,7 @@ CLASS /cc4a/test_prefer_case_elseif IMPLEMENTATION.
     ELSEIF type = 'E'.
       result = 5.
     ENDIF.
+
   ENDMETHOD.
 
   METHOD with_pseudo_comment.
@@ -41,6 +45,80 @@ CLASS /cc4a/test_prefer_case_elseif IMPLEMENTATION.
     ELSEIF type = 'E'.
       result = 5.
     ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_nested_if.
+    DATA(type) = 'A'.
+    DATA(subtype) = 'X'.
+    IF type = 'A'.
+      IF subtype = 'X'.
+        DATA(result) = 1.
+      ELSEIF subtype = 'Y'.
+        result = 2.
+      ELSEIF subtype = 'Z'.
+        result = 3.
+      ELSEIF subtype = 'W'.
+        result = 4.
+      ELSEIF subtype = 'V'.
+        result = 5.
+      ENDIF.
+
+    ELSEIF type = 'B'.
+      result = 6.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_double_nested_if.
+    DATA(type) = 'A'.
+    DATA(subtype1) = 'X'.
+    DATA(subtype2) = 'P'.
+    IF type = 'A'.
+      IF subtype1 = 'X'.
+        DATA(result) = 1.
+      ELSEIF subtype1 = 'Y'.
+        result = 2.
+      ELSEIF subtype1 = 'Z'.
+        result = 3.
+      ELSEIF subtype1 = 'W'.
+        result = 4.
+      ELSEIF subtype1 = 'V'.
+        result = 5.
+      ENDIF.
+
+    ELSEIF type = 'B'.
+      IF subtype2 = 'P'.
+        result = 10.
+      ELSEIF subtype2 = 'Q'.
+        result = 11.
+      ELSEIF subtype2 = 'R'.
+        result = 12.
+      ELSEIF subtype2 = 'S'.
+        result = 13.
+      ELSEIF subtype2 = 'T'.
+        result = 14.
+      ENDIF.
+
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_else_branch.
+    DATA(type) = 'A'.
+    IF type = 'A'.
+      DATA(result) = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
+    ELSE.
+      result = 0.
+    ENDIF.
+
   ENDMETHOD.
 ENDCLASS.
-

--- a/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
@@ -1,0 +1,46 @@
+CLASS /cc4a/test_prefer_case_elseif DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    METHODS with_elseif_chain.
+    METHODS with_pseudo_comment.
+ENDCLASS.
+
+
+
+CLASS /cc4a/test_prefer_case_elseif IMPLEMENTATION.
+  METHOD with_elseif_chain.
+    DATA(type) = 'A'.
+    IF type = 'A'.
+      DATA(result) = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD with_pseudo_comment.
+    DATA(type) = 'A'.
+    IF type = 'A'.                                     "#EC PREFER_CASE
+      DATA(result) = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.
+

--- a/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
@@ -11,6 +11,7 @@ CLASS /cc4a/test_prefer_case_elseif DEFINITION
     METHODS with_nested_if.
     METHODS with_double_nested_if.
     METHODS with_else_branch.
+    METHODS with_or_condition.
 ENDCLASS.
 
 
@@ -118,6 +119,22 @@ CLASS /cc4a/test_prefer_case_elseif IMPLEMENTATION.
       result = 5.
     ELSE.
       result = 0.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_or_condition.
+    DATA(type) = 'A'.
+    IF type = 'A' OR type = 'B'.
+      DATA(result) = 1.
+    ELSEIF type = 'C'.
+      result = 2.
+    ELSEIF type = 'D'.
+      result = 3.
+    ELSEIF type = 'E'.
+      result = 4.
+    ELSEIF type = 'F'.
+      result = 5.
     ENDIF.
 
   ENDMETHOD.

--- a/src/test_objects/#cc4a#test_prefer_case_elseif.clas.xml
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>/CC4A/TEST_PREFER_CASE_ELSEIF</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Test class for check Prefer CASE to ELSE IF</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
@@ -1,0 +1,45 @@
+CLASS /cc4a/test_prefer_case_elseif2 DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    METHODS below_threshold.
+    METHODS mixed_conditions.
+ENDCLASS.
+
+
+
+CLASS /cc4a/test_prefer_case_elseif2 IMPLEMENTATION.
+  METHOD below_threshold.
+    DATA(type) = 'A'.
+    IF type = 'A'.
+      DATA(result) = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD mixed_conditions.
+    DATA(type) = 'A'.
+    DATA(status) = 'X'.
+    IF type = 'A' AND status = 'X'.
+      DATA(result) = 1.
+    ELSEIF type = 'B' AND status = 'Y'.
+      result = 2.
+    ELSEIF type = 'C' AND status = 'Z'.
+      result = 3.
+    ELSEIF type = 'D' AND status = 'W'.
+      result = 4.
+    ELSEIF type = 'E' AND status = 'V'.
+      result = 5.
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.
+

--- a/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
@@ -8,6 +8,9 @@ CLASS /cc4a/test_prefer_case_elseif2 DEFINITION
   PRIVATE SECTION.
     METHODS below_threshold.
     METHODS mixed_conditions.
+    METHODS with_complex_if_condition.
+    METHODS with_mixed_elseif_chain.
+    METHODS with_nondominant_before_else.
 ENDCLASS.
 
 
@@ -24,6 +27,7 @@ CLASS /cc4a/test_prefer_case_elseif2 IMPLEMENTATION.
     ELSEIF type = 'D'.
       result = 4.
     ENDIF.
+
   ENDMETHOD.
 
   METHOD mixed_conditions.
@@ -40,6 +44,76 @@ CLASS /cc4a/test_prefer_case_elseif2 IMPLEMENTATION.
     ELSEIF type = 'E' AND status = 'V'.
       result = 5.
     ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_complex_if_condition.
+    DATA result TYPE i.
+    DATA(type) = 'A'.
+    DATA(subtype) = 'X'.
+    IF type = 'A' AND subtype = 'X'.
+      result = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
+    ELSEIF type = 'F'.
+      result = 6.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_mixed_elseif_chain.
+    DATA result   TYPE i.
+    DATA result_x TYPE i.
+    DATA result_y TYPE i.
+    DATA result_z TYPE i.
+    DATA(type)    = 'A'.
+    DATA(subtype) = 'X'.
+    IF subtype = 'X'.
+      result_x = 0.
+    ELSEIF subtype = 'Y'.
+      result_y = 1.
+    ELSEIF type = 'C'.
+      result = 2.
+    ELSEIF type = 'D'.
+      result = 3.
+    ELSEIF type = 'E'.
+      result = 4.
+    ELSEIF type = 'F'.
+      result = 5.
+    ELSEIF type = 'G'.
+      result = 6.
+    ELSEIF subtype = 'Z'.
+      result_z = 7.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_nondominant_before_else.
+    DATA result   TYPE i.
+    DATA result_x TYPE i.
+    DATA(type)    = 'A'.
+    DATA(subtype) = 'X'.
+    IF type = 'A'.
+      result = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
+    ELSEIF subtype = 'X'.
+      result_x = 6.
+    ELSE.
+      result = 0.
+    ENDIF.
+
   ENDMETHOD.
 ENDCLASS.
-

--- a/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
@@ -11,6 +11,7 @@ CLASS /cc4a/test_prefer_case_elseif2 DEFINITION
     METHODS with_complex_if_condition.
     METHODS with_mixed_elseif_chain.
     METHODS with_nondominant_before_else.
+    METHODS with_or_mixed_variables.
 ENDCLASS.
 
 
@@ -113,6 +114,23 @@ CLASS /cc4a/test_prefer_case_elseif2 IMPLEMENTATION.
       result_x = 6.
     ELSE.
       result = 0.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_or_mixed_variables.
+    DATA(type)   = 'A'.
+    DATA(status) = 'X'.
+    IF type = 'A' OR status = 'X'.
+      DATA(result) = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
     ENDIF.
 
   ENDMETHOD.

--- a/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.xml
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>/CC4A/TEST_PREFER_CASE_ELSEIF2</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Test class for check Prefer CASE to ELSE IF (no findings)</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Closes #12

## Summary

Migrates the _Prefer CASE to ELSEIF_ check from the legacy `code-pal-for-abap` repository to the cloud edition.

The check detects `IF`/`ELSEIF` chains where **all** non-else branches test the same variable (e.g. `IF type = 'A'. ELSEIF type = 'B'. ...`) and the number of such branches meets the threshold (default: 5). A `CASE` statement is more readable in those situations.

- Chains where different variables are used across branches are intentionally not flagged, as they cannot be cleanly expressed as a `CASE` statement.
- Chains with `AND`/`OR` conditions in any branch are not flagged for the same reason.
- Supports pseudo-comment `"#EC PREFER_CASE` to suppress individual findings.
- Includes a quickfix that rewrites the `IF`/`ELSEIF` chain to a `CASE` statement, preserving an `ELSE` branch as `WHEN OTHERS` where present.

## Test plan

- [ ] Activate and compile all new objects without syntax errors
- [ ] Run ATC unit tests — `execute_test_class` and `no_findings` methods both pass
- [ ] Run ATC check against a class containing a 5-branch `IF`/`ELSEIF` chain and verify finding + quickfix output
- [ ] Verify no finding for chains with mixed variables, `AND`/`OR` conditions, or fewer than 5 branches