### PR TITLE
Modern Language: Add Support for READ TABLE WITH TABLE KEY

### DIFF
--- a/src/checks/#cc4a#modern_language.clas.abap
+++ b/src/checks/#cc4a#modern_language.clas.abap
@@ -1,147 +1,147 @@
-class /cc4a/modern_language definition
-  public
-  final
-  create public .
+CLASS /cc4a/modern_language DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-  public section.
+  PUBLIC SECTION.
 
-    interfaces if_ci_atc_check .
+    INTERFACES if_ci_atc_check .
 
-  protected section.
-  private section.
-    constants:
-      begin of message_codes,
-        move                type if_ci_atc_check=>ty_finding_code value 'MOVE',
-        translate           type if_ci_atc_check=>ty_finding_code value 'TRANSLATE',
-        line_exists         type if_ci_atc_check=>ty_finding_code value 'LINE_EXIST',
-        prefer_new          type if_ci_atc_check=>ty_finding_code value 'PREFER_NEW',
-        call_method         type if_ci_atc_check=>ty_finding_code value 'CALL_METH',
-        method_exporting    type if_ci_atc_check=>ty_finding_code value 'METH_EXP',
-        exporting_receiving type if_ci_atc_check=>ty_finding_code value 'EXP_REC',
-        text_assembly       type if_ci_atc_check=>ty_finding_code value 'TEXT_ASM',
-      end of message_codes.
-    constants:
-      begin of quickfix_codes,
-        move                type cl_ci_atc_quickfixes=>ty_quickfix_code value 'QF_MOVE',
-        translate           type cl_ci_atc_quickfixes=>ty_quickfix_code value 'QF_TRANSL',
-        line_exists         type cl_ci_atc_quickfixes=>ty_quickfix_code value 'QF_LINEEX',
-        prefer_new          type cl_ci_atc_quickfixes=>ty_quickfix_code value 'QF_PREFNEW',
-        call_method         type cl_ci_atc_quickfixes=>ty_quickfix_code value 'QF_CALLM',
-        method_exporting    type cl_ci_atc_quickfixes=>ty_quickfix_code value 'QF_MEXP',
-        exporting_receiving type cl_ci_atc_quickfixes=>ty_quickfix_code value 'QF_EXP_REC',
-        text_assembly       type cl_ci_atc_quickfixes=>ty_quickfix_code value 'QF_TEXTASM',
-      end of quickfix_codes.
-    constants:
-      begin of pseudo_comments,
-        deprecated_key      type string value 'DEPRECATED_KEY',
-        line_exists         type string value 'PREF_LINE_EX',
-        prefer_new          type string value 'PREF_NEW',
-        call_method         type string value 'CALL_METH_USAGE',
-        method_exporting    type string value 'OPTL_EXP',
-        exporting_receiving type string value 'RECEIVING_USAGE',
-        text_assembly       type string value 'TEXT_ASSEMBLY',
-      end of pseudo_comments.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    CONSTANTS:
+      BEGIN OF message_codes,
+        move                TYPE if_ci_atc_check=>ty_finding_code VALUE 'MOVE',
+        translate           TYPE if_ci_atc_check=>ty_finding_code VALUE 'TRANSLATE',
+        line_exists         TYPE if_ci_atc_check=>ty_finding_code VALUE 'LINE_EXIST',
+        prefer_new          TYPE if_ci_atc_check=>ty_finding_code VALUE 'PREFER_NEW',
+        call_method         TYPE if_ci_atc_check=>ty_finding_code VALUE 'CALL_METH',
+        method_exporting    TYPE if_ci_atc_check=>ty_finding_code VALUE 'METH_EXP',
+        exporting_receiving TYPE if_ci_atc_check=>ty_finding_code VALUE 'EXP_REC',
+        text_assembly       TYPE if_ci_atc_check=>ty_finding_code VALUE 'TEXT_ASM',
+      END OF message_codes.
+    CONSTANTS:
+      BEGIN OF quickfix_codes,
+        move                TYPE cl_ci_atc_quickfixes=>ty_quickfix_code VALUE 'QF_MOVE',
+        translate           TYPE cl_ci_atc_quickfixes=>ty_quickfix_code VALUE 'QF_TRANSL',
+        line_exists         TYPE cl_ci_atc_quickfixes=>ty_quickfix_code VALUE 'QF_LINEEX',
+        prefer_new          TYPE cl_ci_atc_quickfixes=>ty_quickfix_code VALUE 'QF_PREFNEW',
+        call_method         TYPE cl_ci_atc_quickfixes=>ty_quickfix_code VALUE 'QF_CALLM',
+        method_exporting    TYPE cl_ci_atc_quickfixes=>ty_quickfix_code VALUE 'QF_MEXP',
+        exporting_receiving TYPE cl_ci_atc_quickfixes=>ty_quickfix_code VALUE 'QF_EXP_REC',
+        text_assembly       TYPE cl_ci_atc_quickfixes=>ty_quickfix_code VALUE 'QF_TEXTASM',
+      END OF quickfix_codes.
+    CONSTANTS:
+      BEGIN OF pseudo_comments,
+        deprecated_key      TYPE string VALUE 'DEPRECATED_KEY',
+        line_exists         TYPE string VALUE 'PREF_LINE_EX',
+        prefer_new          TYPE string VALUE 'PREF_NEW',
+        call_method         TYPE string VALUE 'CALL_METH_USAGE',
+        method_exporting    TYPE string VALUE 'OPTL_EXP',
+        exporting_receiving TYPE string VALUE 'RECEIVING_USAGE',
+        text_assembly       TYPE string VALUE 'TEXT_ASSEMBLY',
+      END OF pseudo_comments.
 
-    types: begin of ty_receiving_infos,
-             receiving_idx type i,
-             end_idx       type i,
-             result_line   type string,
-           end of ty_receiving_infos.
-    data code_provider     type ref to if_ci_atc_source_code_provider.
-    data analyzer type ref to /cc4a/if_abap_analyzer.
-    data assistant_factory type ref to cl_ci_atc_assistant_factory.
+    TYPES: BEGIN OF ty_receiving_infos,
+             receiving_idx TYPE i,
+             end_idx       TYPE i,
+             result_line   TYPE string,
+           END OF ty_receiving_infos.
+    DATA code_provider     TYPE REF TO if_ci_atc_source_code_provider.
+    DATA analyzer TYPE REF TO /cc4a/if_abap_analyzer.
+    DATA assistant_factory TYPE REF TO cl_ci_atc_assistant_factory.
 
-    methods analyze_procedure
-      importing procedure       type if_ci_atc_source_code_provider=>ty_procedure
-      returning value(findings) type if_ci_atc_check=>ty_findings.
-    methods analyze_move
-      importing procedure       type if_ci_atc_source_code_provider=>ty_procedure
-                statement_index type i
-      returning value(findings) type if_ci_atc_check=>ty_findings.
-    methods analyze_translate
-      importing procedure       type if_ci_atc_source_code_provider=>ty_procedure
-                statement_index type i
-      returning value(findings) type if_ci_atc_check=>ty_findings.
-    methods analyze_read
-      importing procedure       type if_ci_atc_source_code_provider=>ty_procedure
-                statement_index type i
-      returning value(findings) type if_ci_atc_check=>ty_findings.
-    methods analyze_loop
-      importing procedure       type if_ci_atc_source_code_provider=>ty_procedure
-                statement_index type i
-      returning value(findings) type if_ci_atc_check=>ty_findings.
-    methods analyze_create_object
-      importing procedure       type if_ci_atc_source_code_provider=>ty_procedure
-                statement_index type i
-      returning value(findings) type if_ci_atc_check=>ty_findings.
-    methods analyze_call_method
-      importing procedure       type if_ci_atc_source_code_provider=>ty_procedure
-                statement_index type i
-      returning value(findings) type if_ci_atc_check=>ty_findings.
-    methods analyze_exporting_receiving
-      importing procedure       type if_ci_atc_source_code_provider=>ty_procedure
-                statement_index type i
-      returning value(findings) type if_ci_atc_check=>ty_findings.
-    methods analyze_text_assembly
-      importing procedure       type if_ci_atc_source_code_provider=>ty_procedure
-                statement_index type i
-      returning value(findings) type if_ci_atc_check=>ty_findings.
-    methods add_finding
-      importing quickfixes      type ref to cl_ci_atc_quickfixes optional
-                procedure       type if_ci_atc_source_code_provider=>ty_procedure
-                statement_index type i
-                code            type cl_ci_atc_quickfixes=>ty_quickfix_code
-                pseudo_comment  type string
-      changing  findings        type if_ci_atc_check=>ty_findings.
-    methods is_used
-      importing
-        procedure     type if_ci_atc_source_code_provider=>ty_procedure
-        from_index    type i
-        full_name     type string
-      returning
-        value(result) type abap_bool.
+    METHODS analyze_procedure
+      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+    METHODS analyze_move
+      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+                statement_index TYPE i
+      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+    METHODS analyze_translate
+      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+                statement_index TYPE i
+      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+    METHODS analyze_read
+      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+                statement_index TYPE i
+      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+    METHODS analyze_loop
+      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+                statement_index TYPE i
+      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+    METHODS analyze_create_object
+      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+                statement_index TYPE i
+      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+    METHODS analyze_call_method
+      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+                statement_index TYPE i
+      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+    METHODS analyze_exporting_receiving
+      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+                statement_index TYPE i
+      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+    METHODS analyze_text_assembly
+      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+                statement_index TYPE i
+      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+    METHODS add_finding
+      IMPORTING quickfixes      TYPE REF TO cl_ci_atc_quickfixes OPTIONAL
+                procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+                statement_index TYPE i
+                code            TYPE cl_ci_atc_quickfixes=>ty_quickfix_code
+                pseudo_comment  TYPE string
+      CHANGING  findings        TYPE if_ci_atc_check=>ty_findings.
+    METHODS is_used
+      IMPORTING
+        procedure     TYPE if_ci_atc_source_code_provider=>ty_procedure
+        from_index    TYPE i
+        full_name     TYPE string
+      RETURNING
+        VALUE(result) TYPE abap_bool.
 
-    methods check_remove_exporting
-      importing
-        statement     type if_ci_atc_source_code_provider=>ty_statement
-        token_idx     type i
-      returning
-        value(result) type abap_bool.
-    methods get_value
-      importing token         type if_ci_atc_source_code_provider=>ty_token
-      returning value(result) type string
-      raising   lcx_error.
-    methods append_token
-      importing token  type if_ci_atc_source_code_provider=>ty_token
-      changing  result type string.
-    methods append_tokens
-      importing tokens          type if_ci_atc_source_code_provider=>ty_tokens
-                value(from_idx) type i optional
-                value(to_idx)   type i optional
-      changing  result          type string.
-    methods get_receiving_infos
-      importing
-                tokens        type if_ci_atc_source_code_provider=>ty_tokens
-      returning value(result) type ty_receiving_infos.
-    methods get_move_changed_line
-      importing statement     type if_ci_atc_source_code_provider=>ty_statement
-      returning value(result) type string.
-endclass.
-
-
-
-class /cc4a/modern_language implementation.
+    METHODS check_remove_exporting
+      IMPORTING
+        statement     TYPE if_ci_atc_source_code_provider=>ty_statement
+        token_idx     TYPE i
+      RETURNING
+        VALUE(result) TYPE abap_bool.
+    METHODS get_value
+      IMPORTING token         TYPE if_ci_atc_source_code_provider=>ty_token
+      RETURNING VALUE(result) TYPE string
+      RAISING   lcx_error.
+    METHODS append_token
+      IMPORTING token  TYPE if_ci_atc_source_code_provider=>ty_token
+      CHANGING  result TYPE string.
+    METHODS append_tokens
+      IMPORTING tokens          TYPE if_ci_atc_source_code_provider=>ty_tokens
+                VALUE(from_idx) TYPE i OPTIONAL
+                VALUE(to_idx)   TYPE i OPTIONAL
+      CHANGING  result          TYPE string.
+    METHODS get_receiving_infos
+      IMPORTING
+                tokens        TYPE if_ci_atc_source_code_provider=>ty_tokens
+      RETURNING VALUE(result) TYPE ty_receiving_infos.
+    METHODS get_move_changed_line
+      IMPORTING statement     TYPE if_ci_atc_source_code_provider=>ty_statement
+      RETURNING VALUE(result) TYPE string.
+ENDCLASS.
 
 
 
+CLASS /cc4a/modern_language IMPLEMENTATION.
 
 
-  method if_ci_atc_check~get_meta_data.
+
+
+
+  METHOD if_ci_atc_check~get_meta_data.
     meta_data = /cc4a/check_meta_data=>create(
-        value #( checked_types = /cc4a/check_meta_data=>checked_types-abap_programs
+        VALUE #( checked_types = /cc4a/check_meta_data=>checked_types-abap_programs
         description = 'Modern Language'(des)
         remote_enablement = /cc4a/check_meta_data=>remote_enablement-unconditional
-        finding_codes = value #( ( code = message_codes-move  text = 'MOVE is obsolete'(001) pseudo_comment = pseudo_comments-deprecated_key )
+        finding_codes = VALUE #( ( code = message_codes-move  text = 'MOVE is obsolete'(001) pseudo_comment = pseudo_comments-deprecated_key )
                                  ( code = message_codes-translate text = 'TRANSLATE TO UPPER/LOWERCASE is obsolete'(002) pseudo_comment = pseudo_comments-deprecated_key )
                                  ( code = message_codes-line_exists text = 'Prefer LINE_EXISTS/LINE_INDEX'(003) pseudo_comment = pseudo_comments-line_exists )
                                  ( code = message_codes-prefer_new text = 'Prefer NEW instead of CREATE OBJECT'(004) pseudo_comment = pseudo_comments-prefer_new )
@@ -149,7 +149,7 @@ class /cc4a/modern_language implementation.
                                  ( code = message_codes-method_exporting text = 'Omit EXPORTING in functional Method Call if possible'(006) pseudo_comment = pseudo_comments-method_exporting )
                                  ( code = message_codes-exporting_receiving text = 'Do not use RECEIVING in functional Method Call if possible'(007) pseudo_comment = pseudo_comments-exporting_receiving )
                                  ( code = message_codes-text_assembly text = 'Use string templates instead of &&'(008) pseudo_comment = pseudo_comments-text_assembly ) )
-        quickfix_codes = value #( ( code = quickfix_codes-move short_text = 'Replace MOVE statement'(qf1) )
+        quickfix_codes = VALUE #( ( code = quickfix_codes-move short_text = 'Replace MOVE statement'(qf1) )
                                   ( code = quickfix_codes-translate short_text = 'Replace TRANSLATE statement'(qf2) )
                                   ( code = quickfix_codes-line_exists short_text = 'Use LINE_EXISTS/LINE_INDEX'(qf3) )
                                   ( code = quickfix_codes-prefer_new short_text = 'Use NEW instead of CREATE OBJECT'(qf4) )
@@ -158,931 +158,938 @@ class /cc4a/modern_language implementation.
                                   ( code = quickfix_codes-exporting_receiving short_text = 'Do not use EXPORTING/RECEIVING'(qf7) )
                                   ( code = quickfix_codes-text_assembly short_text = 'Replace && by string templates'(qf8) )
                                    ) ) ).
-  endmethod.
+  ENDMETHOD.
 
 
-  method if_ci_atc_check~run.
+  METHOD if_ci_atc_check~run.
     code_provider = data_provider->get_code_provider( ).
     analyzer = /cc4a/abap_analyzer=>create( ).
-    data(procedures) = code_provider->get_procedures( code_provider->object_to_comp_unit( object ) ).
-    loop at procedures->* assigning field-symbol(<procedure>).
-      insert lines of analyze_procedure( <procedure> ) into table findings.
-    endloop.
-  endmethod.
+    DATA(procedures) = code_provider->get_procedures( code_provider->object_to_comp_unit( object ) ).
+    LOOP AT procedures->* ASSIGNING FIELD-SYMBOL(<procedure>).
+      INSERT LINES OF analyze_procedure( <procedure> ) INTO TABLE findings.
+    ENDLOOP.
+  ENDMETHOD.
 
 
-  method if_ci_atc_check~set_assistant_factory.
+  METHOD if_ci_atc_check~set_assistant_factory.
     assistant_factory = factory.
-  endmethod.
+  ENDMETHOD.
 
 
-  method if_ci_atc_check~set_attributes ##NEEDED.
-  endmethod.
+  METHOD if_ci_atc_check~set_attributes ##NEEDED.
+  ENDMETHOD.
 
 
-  method if_ci_atc_check~verify_prerequisites ##NEEDED.
-  endmethod.
+  METHOD if_ci_atc_check~verify_prerequisites ##NEEDED.
+  ENDMETHOD.
 
 
-  method add_finding.
-    data finding like line of findings.
-    data(statement) = procedure-statements[ statement_index ].
-    if quickfixes is initial.
-      finding = value #( code = code
+  METHOD add_finding.
+    DATA finding LIKE LINE OF findings.
+    DATA(statement) = procedure-statements[ statement_index ].
+    IF quickfixes IS INITIAL.
+      finding = VALUE #( code = code
               location = code_provider->get_statement_location( statement )
               checksum = code_provider->get_statement_checksum( statement )
               has_pseudo_comment = xsdbool( line_exists( statement-pseudo_comments[ table_line = pseudo_comment ] ) )
                ).
 
-    else.
-      finding = value #( code = code
+    ELSE.
+      finding = VALUE #( code = code
               location = code_provider->get_statement_location( statement )
               checksum = code_provider->get_statement_checksum( statement )
               has_pseudo_comment = xsdbool( line_exists( statement-pseudo_comments[ table_line = pseudo_comment ] ) )
               details = assistant_factory->create_finding_details( )->attach_quickfixes( quickfixes ) ).
-    endif.
-    insert finding into table findings.
-  endmethod.
+    ENDIF.
+    INSERT finding INTO TABLE findings.
+  ENDMETHOD.
 
-  method get_move_changed_line.
-    data source type string.
-    data dest type string.
-    data between type string.
+  METHOD get_move_changed_line.
+    DATA source TYPE string.
+    DATA dest TYPE string.
+    DATA between TYPE string.
 
-    data(from_token) = 2.
-    if statement-tokens[ 2 ]-lexeme = 'EXACT' and statement-tokens[ 2 ]-references is initial.
-      data(exact) = abap_true.
+    DATA(from_token) = 2.
+    IF statement-tokens[ 2 ]-lexeme = 'EXACT' AND statement-tokens[ 2 ]-references IS INITIAL.
+      DATA(exact) = abap_true.
       from_token = 3.
-    endif.
-    loop at statement-tokens from from_token assigning field-symbol(<token>).
+    ENDIF.
+    LOOP AT statement-tokens FROM from_token ASSIGNING FIELD-SYMBOL(<token>).
 
-      if <token>-references is initial.
-        case <token>-lexeme.
-          when 'TO'.
-            if exact = abap_true.
+      IF <token>-references IS INITIAL.
+        CASE <token>-lexeme.
+          WHEN 'TO'.
+            IF exact = abap_true.
               between = `= EXACT #(`.
-            else.
+            ELSE.
               between = `=`.
-            endif.
-            continue.
-          when '?TO'.
+            ENDIF.
+            CONTINUE.
+          WHEN '?TO'.
             between = `?=`.
-            continue.
-        endcase.
-      endif.
-      if between is initial.
+            CONTINUE.
+        ENDCASE.
+      ENDIF.
+      IF between IS INITIAL.
         source = |{ source } { <token>-lexeme }|.
-      else.
+      ELSE.
         dest = |{ dest } { <token>-lexeme }|.
-      endif.
-    endloop.
+      ENDIF.
+    ENDLOOP.
     result = |{ dest } { between } { source }|.
-    if exact = abap_true.
+    IF exact = abap_true.
       result = |{ result } )|.
-    endif.
+    ENDIF.
     result = |{ result }.|.
-  endmethod.
+  ENDMETHOD.
 
-  method analyze_move.
-    data(statement) = procedure-statements[ statement_index ].
+  METHOD analyze_move.
+    DATA(statement) = procedure-statements[ statement_index ].
 
-    if analyzer->find_clause_index( tokens = statement-tokens clause = 'PERCENTAGE' ) <> 0.
+    IF analyzer->find_clause_index( tokens = statement-tokens clause = 'PERCENTAGE' ) <> 0.
       add_finding(
-      exporting
+      EXPORTING
          procedure = procedure
          statement_index = statement_index
          code = message_codes-move
          pseudo_comment = pseudo_comments-deprecated_key
-      changing findings = findings ).
-    else.
-      data(line) = get_move_changed_line( statement ).
-      data(quickfixes) = assistant_factory->create_quickfixes( ).
-      data(quickfix) = quickfixes->create_quickfix( quickfix_codes-move ).
+      CHANGING findings = findings ).
+    ELSE.
+      DATA(line) = get_move_changed_line( statement ).
+      DATA(quickfixes) = assistant_factory->create_quickfixes( ).
+      DATA(quickfix) = quickfixes->create_quickfix( quickfix_codes-move ).
       quickfix->replace(
           context = assistant_factory->create_quickfix_context(
-             value #( procedure_id = procedure-id statements = value #( from = statement_index to = statement_index ) ) )
-                      code = value #( ( line ) ) ).
+             VALUE #( procedure_id = procedure-id statements = VALUE #( from = statement_index to = statement_index ) ) )
+                      code = VALUE #( ( line ) ) ).
 
       add_finding(
-      exporting
+      EXPORTING
          procedure = procedure
          statement_index = statement_index
          code = message_codes-move
          pseudo_comment = pseudo_comments-deprecated_key
          quickfixes = quickfixes
-      changing findings = findings ).
-    endif.
-  endmethod.
+      CHANGING findings = findings ).
+    ENDIF.
+  ENDMETHOD.
 
 
-  method analyze_translate.
-    data(statement) = procedure-statements[ statement_index ].
-    if analyzer->find_clause_index(  tokens = statement-tokens clause = 'USING MASK' ) <> 0.
-      return.
-    endif.
-    if analyzer->find_clause_index( tokens = statement-tokens clause = 'TO UPPER CASE' ) = 3
-    or analyzer->find_clause_index( tokens = statement-tokens clause = 'TO LOWER CASE' ) = 3.
+  METHOD analyze_translate.
+    DATA(statement) = procedure-statements[ statement_index ].
+    IF analyzer->find_clause_index(  tokens = statement-tokens clause = 'USING MASK' ) <> 0.
+      RETURN.
+    ENDIF.
+    IF analyzer->find_clause_index( tokens = statement-tokens clause = 'TO UPPER CASE' ) = 3
+    OR analyzer->find_clause_index( tokens = statement-tokens clause = 'TO LOWER CASE' ) = 3.
 
       add_finding(
-      exporting
+      EXPORTING
          procedure = procedure
          statement_index = statement_index
          code = message_codes-translate
          pseudo_comment = pseudo_comments-deprecated_key
-      changing findings = findings ).
-    endif.
-  endmethod.
+      CHANGING findings = findings ).
+    ENDIF.
+  ENDMETHOD.
 
 
-  method analyze_read.
-    data code_line_index type string.
-    data code_line_exists type string.
-    data code_lines type if_ci_atc_quickfix=>ty_code.
-    data key  type string.
-    data token_idx type i.
-    data(statement) = procedure-statements[ statement_index ].
+  METHOD analyze_read.
+    DATA code_line_index TYPE string.
+    DATA code_line_exists TYPE string.
+    DATA code_lines TYPE if_ci_atc_quickfix=>ty_code.
+    DATA key  TYPE string.
+    DATA token_idx TYPE i.
+    DATA(statement) = procedure-statements[ statement_index ].
 
 
-    if lines( statement-tokens ) <= 2 or statement-tokens[ 2 ]-lexeme <> 'TABLE' or statement-tokens[ 2 ]-references is not initial
-    or lines( procedure-statements ) = statement_index
-    or analyzer->find_clause_index(  tokens = statement-tokens clause = 'TRANSPORTING NO FIELDS' ) = 0
-    or analyzer->find_clause_index( tokens = statement-tokens clause = 'INDEX' ) <> 0
-    or analyzer->find_clause_index( tokens = statement-tokens clause = 'BINARY SEARCH' ) <> 0
-    or statement-tokens[ 3 ]-lexeme cp '*('.
-      return.
-    endif.
-    data(key_idx) = analyzer->find_clause_index(  tokens = statement-tokens clause = 'WITH KEY' ).
-    if key_idx = 0.
-      return.
-    else.
+    IF lines( statement-tokens ) <= 2 OR statement-tokens[ 2 ]-lexeme <> 'TABLE' OR statement-tokens[ 2 ]-references IS NOT INITIAL
+    OR lines( procedure-statements ) = statement_index
+    OR analyzer->find_clause_index(  tokens = statement-tokens clause = 'TRANSPORTING NO FIELDS' ) = 0
+    OR analyzer->find_clause_index( tokens = statement-tokens clause = 'INDEX' ) <> 0
+    OR analyzer->find_clause_index( tokens = statement-tokens clause = 'BINARY SEARCH' ) <> 0
+    OR statement-tokens[ 3 ]-lexeme CP '*('.
+      RETURN.
+    ENDIF.
+    DATA(key_idx) = analyzer->find_clause_index(  tokens = statement-tokens clause = 'WITH KEY' ).
+    IF key_idx = 0.
+      key_idx = analyzer->find_clause_index( tokens = statement-tokens clause = 'WITH TABLE KEY' ).
+      IF key_idx = 0.
+        RETURN.
+      ENDIF.
+      DATA(with_table_key) = abap_true.
+    ENDIF.
 
-      data(start_idx) = analyzer->find_clause_index(  tokens = statement-tokens clause = 'COMPONENTS'
-                                                      start_index = key_idx + 1 ).
-      if start_idx = 0. "with key...
+    DATA(start_idx) = analyzer->find_clause_index(  tokens = statement-tokens clause = 'COMPONENTS'
+                                                    start_index = key_idx + 1 ).
+    IF start_idx = 0. "with key...
+      IF with_table_key = abap_true.
+        start_idx = key_idx + 3.
+      ELSE.
         start_idx = key_idx + 2.
-      else. "with key name components ...
-        start_idx -= 2.
-      endif.
-      data(keylen) = 0.
-      data(to_idx) =  analyzer->find_clause_index( tokens = statement-tokens clause = 'TRANSPORTING' start_index = start_idx ) - 1.
-      if to_idx <= 0.
-        to_idx = lines( statement-tokens ).
-      endif.
-      if statement-tokens[ key_idx + 2 ]-lexeme = '='.
-        key = 'TABLE_LINE'.
-        append_tokens( exporting tokens = statement-tokens from_idx = key_idx + 2 to_idx = to_idx
-                       changing result = key ).
-      else.
-        append_tokens( exporting tokens = statement-tokens from_idx = start_idx to_idx = to_idx
-                       changing result = key ).
-      endif.
-      keylen = to_idx - start_idx + 1.
+      ENDIF.
+    ELSE. "with key name components ...
+      start_idx -= 2.
+    ENDIF.
+    DATA(keylen) = 0.
+    DATA(to_idx) =  analyzer->find_clause_index( tokens = statement-tokens clause = 'TRANSPORTING' start_index = start_idx ) - 1.
+    IF to_idx <= 0.
+      to_idx = lines( statement-tokens ).
+    ENDIF.
+    IF statement-tokens[ key_idx + 2 ]-lexeme = '='.
+      key = 'TABLE_LINE'.
+      append_tokens( EXPORTING tokens = statement-tokens from_idx = key_idx + 2 to_idx = to_idx
+                     CHANGING result = key ).
+    ELSE.
+      append_tokens( EXPORTING tokens = statement-tokens from_idx = start_idx to_idx = to_idx
+                     CHANGING result = key ).
+    ENDIF.
+    keylen = to_idx - start_idx + 1.
 
-    endif.
-    if keylen = 1.
+    IF keylen = 1.
 *     finding without quickfix since obsolete version read table with key val.
       add_finding(
-      exporting
+      EXPORTING
          procedure = procedure
          statement_index = statement_index
          code = message_codes-line_exists
          pseudo_comment = pseudo_comments-line_exists
-      changing findings = findings ).
-      return.
-    endif.
-    data(quickfixable) = abap_true.
-    data(table) = statement-tokens[ 3 ]-lexeme.
-    if table cp '*[]'.
-      data(len) = strlen( table ) - 2.
+      CHANGING findings = findings ).
+      RETURN.
+    ENDIF.
+    DATA(quickfixable) = abap_true.
+    DATA(table) = statement-tokens[ 3 ]-lexeme.
+    IF table CP '*[]'.
+      DATA(len) = strlen( table ) - 2.
       table = table(len).
-    endif.
-    data(idx) = statement_index + 1.
-    assign procedure-statements[ idx ] to field-symbol(<next_statement>).
-    if <next_statement>-keyword = 'IF' and lines( <next_statement>-tokens ) = 4
-    and <next_statement>-tokens[ 2 ]-lexeme = 'SY-SUBRC'
+    ENDIF.
+    DATA(idx) = statement_index + 1.
+    ASSIGN procedure-statements[ idx ] TO FIELD-SYMBOL(<next_statement>).
+    IF <next_statement>-keyword = 'IF' AND lines( <next_statement>-tokens ) = 4
+    AND <next_statement>-tokens[ 2 ]-lexeme = 'SY-SUBRC'
 
-    and <next_statement>-tokens[ 4 ]-lexeme = '0'.
-      case  <next_statement>-tokens[ 3 ]-lexeme.
-        when '=' or 'EQ' .
-          data(if_sysubrc) = 1.
-        when '<>' or 'NE'.
+    AND <next_statement>-tokens[ 4 ]-lexeme = '0'.
+      CASE  <next_statement>-tokens[ 3 ]-lexeme.
+        WHEN '=' OR 'EQ' .
+          DATA(if_sysubrc) = 1.
+        WHEN '<>' OR 'NE'.
           if_sysubrc = 2.
-      endcase.
+      ENDCASE.
       idx += 1.
-    endif.
-    data(end_idx) = idx.
-    if if_sysubrc <> 0.
+    ENDIF.
+    DATA(end_idx) = idx.
+    IF if_sysubrc <> 0.
       to_idx = lines(  procedure-statements ).
-    else.
+    ELSE.
       to_idx = idx.
-    endif.
-    loop at procedure-statements from idx to to_idx assigning field-symbol(<statement>).
-      data(tabix) = sy-tabix.
-      if <statement>-keyword = 'ENDIF'.
+    ENDIF.
+    LOOP AT procedure-statements FROM idx TO to_idx ASSIGNING FIELD-SYMBOL(<statement>).
+      DATA(tabix) = sy-tabix.
+      IF <statement>-keyword = 'ENDIF'.
         end_idx = sy-tabix.
-        exit.
-      endif.
-      data(sytabix_idx) = line_index( <statement>-tokens[ lexeme = 'SY-TABIX' ] ).
+        EXIT.
+      ENDIF.
+      DATA(sytabix_idx) = line_index( <statement>-tokens[ lexeme = 'SY-TABIX' ] ).
 
-      if sytabix_idx <> 0.
-        if sytabix_idx > 1 and <statement>-tokens[ sytabix_idx - 1 ]-lexeme = '&&'.
+      IF sytabix_idx <> 0.
+        IF sytabix_idx > 1 AND <statement>-tokens[ sytabix_idx - 1 ]-lexeme = '&&'.
           quickfixable = abap_false.
-          exit.
-        endif.
-        if sytabix_idx > 1 and <statement>-tokens[ sytabix_idx - 1 ]-references is initial
-        and <statement>-tokens[ sytabix_idx - 1 ]-lexeme = 'LIKE'
-        and <statement>-keyword = 'DATA'.
+          EXIT.
+        ENDIF.
+        IF sytabix_idx > 1 AND <statement>-tokens[ sytabix_idx - 1 ]-references IS INITIAL
+        AND <statement>-tokens[ sytabix_idx - 1 ]-lexeme = 'LIKE'
+        AND <statement>-keyword = 'DATA'.
           quickfixable = abap_false.
-          exit.
-        endif.
-        case <statement>-keyword.
-          when 'MOVE'.
+          EXIT.
+        ENDIF.
+        CASE <statement>-keyword.
+          WHEN 'MOVE'.
             code_line_index = get_move_changed_line( <statement> ).
-            replace first occurrence of 'SY-TABIX' in code_line_index with |line_index( { table }[ { key } ] )| ##NO_TEXT.
-            append code_line_index to code_lines.
-          when 'MESSAGE' or 'PERFORM' or '+CALL_MACRO'.
+            REPLACE FIRST OCCURRENCE OF 'SY-TABIX' IN code_line_index WITH |line_index( { table }[ { key } ] )| ##NO_TEXT.
+            APPEND code_line_index TO code_lines.
+          WHEN 'MESSAGE' OR 'PERFORM' OR '+CALL_MACRO'.
             quickfixable = abap_false.
-            exit.
-          when 'SET'.
-            if <statement>-tokens[ 2 ]-references is initial and <statement>-tokens[ 2 ]-lexeme = 'BIT'.
+            EXIT.
+          WHEN 'SET'.
+            IF <statement>-tokens[ 2 ]-references IS INITIAL AND <statement>-tokens[ 2 ]-lexeme = 'BIT'.
               quickfixable = abap_false.
-            endif.
-          when others.
-            if if_sysubrc <> 2.
+            ENDIF.
+          WHEN OTHERS.
+            IF if_sysubrc <> 2.
               code_line_index = analyzer->flatten_tokens( tokens = <statement>-tokens ).
-              replace first occurrence of 'SY-TABIX IS INITIAL' in code_line_index with |line_index( { table }[ { key } ] ) = 0| ##NO_TEXT.
-              replace first occurrence of 'SY-TABIX IS NOT INITIAL' in code_line_index with |line_index( { table }[ { key } ] ) <> 0| ##NO_TEXT.
-              replace first occurrence of 'SY-TABIX' in code_line_index with |line_index( { table }[ { key } ] )| ##NO_TEXT.
+              REPLACE FIRST OCCURRENCE OF 'SY-TABIX IS INITIAL' IN code_line_index WITH |line_index( { table }[ { key } ] ) = 0| ##NO_TEXT.
+              REPLACE FIRST OCCURRENCE OF 'SY-TABIX IS NOT INITIAL' IN code_line_index WITH |line_index( { table }[ { key } ] ) <> 0| ##NO_TEXT.
+              REPLACE FIRST OCCURRENCE OF 'SY-TABIX' IN code_line_index WITH |line_index( { table }[ { key } ] )| ##NO_TEXT.
               code_line_index = |{ code_line_index }.|.
-              append code_line_index to code_lines.
-            endif.
-        endcase.
-      elseif if_sysubrc <> 0 and tabix > statement_index + 1.
-        if <statement>-keyword = 'CALL' or <statement>-keyword = '+CALL_METHOD'.
+              APPEND code_line_index TO code_lines.
+            ENDIF.
+        ENDCASE.
+      ELSEIF if_sysubrc <> 0 AND tabix > statement_index + 1.
+        IF <statement>-keyword = 'CALL' OR <statement>-keyword = '+CALL_METHOD'.
           quickfixable = abap_false.
-          exit.
-        endif.
-        case if_sysubrc.
-          when 1.
+          EXIT.
+        ENDIF.
+        CASE if_sysubrc.
+          WHEN 1.
             token_idx = analyzer->find_clause_index( tokens = <statement>-tokens clause = '=' ).
-            if token_idx = 0 or <statement>-tokens[ token_idx + 1 ]-lexeme <> 'ABAP_TRUE'.
+            IF token_idx = 0 OR <statement>-tokens[ token_idx + 1 ]-lexeme <> 'ABAP_TRUE'.
               quickfixable = abap_false.
-              exit.
-            endif.
-          when 2.
+              EXIT.
+            ENDIF.
+          WHEN 2.
             token_idx = analyzer->find_clause_index( tokens = <statement>-tokens clause = '=' ).
-            if token_idx = 0 or <statement>-tokens[ token_idx + 1 ]-lexeme <> 'ABAP_FALSE'
-            or procedure-statements[ tabix + 1 ]-keyword <> 'ENDIF'.
+            IF token_idx = 0 OR <statement>-tokens[ token_idx + 1 ]-lexeme <> 'ABAP_FALSE'
+            OR procedure-statements[ tabix + 1 ]-keyword <> 'ENDIF'.
               quickfixable = abap_false.
-              exit.
-            endif.
-        endcase.
-        append_tokens( exporting tokens = <statement>-tokens to_idx = token_idx - 1 changing result = code_line_exists ).
-        if if_sysubrc = 1.
+              EXIT.
+            ENDIF.
+        ENDCASE.
+        append_tokens( EXPORTING tokens = <statement>-tokens to_idx = token_idx - 1 CHANGING result = code_line_exists ).
+        IF if_sysubrc = 1.
           code_line_exists = |{ code_line_exists } = xsdbool( line_exists( { table }[ { key } ] ) ).| ##NO_TEXT.
-        else.
+        ELSE.
           code_line_exists = |{ code_line_exists } = xsdbool( NOT line_exists( { table }[ { key } ] ) ).| ##NO_TEXT.
-        endif.
-        append code_line_exists to code_lines.
-      endif.
-      if if_sysubrc = 0.
-        exit.
-      endif.
-    endloop.
+        ENDIF.
+        APPEND code_line_exists TO code_lines.
+      ENDIF.
+      IF if_sysubrc = 0.
+        EXIT.
+      ENDIF.
+    ENDLOOP.
 
-    if quickfixable = abap_true and ( code_line_index is not initial or code_line_exists is not initial ).
-      data(quickfixes) = assistant_factory->create_quickfixes( ).
-      data(quickfix) = quickfixes->create_quickfix( quickfix_codes-line_exists ).
+    IF quickfixable = abap_true AND ( code_line_index IS NOT INITIAL OR code_line_exists IS NOT INITIAL ).
+      DATA(quickfixes) = assistant_factory->create_quickfixes( ).
+      DATA(quickfix) = quickfixes->create_quickfix( quickfix_codes-line_exists ).
 
       quickfix->replace(
           context = assistant_factory->create_quickfix_context(
-             value #( procedure_id = procedure-id statements = value #( from = statement_index to = end_idx ) ) )
+             VALUE #( procedure_id = procedure-id statements = VALUE #( from = statement_index to = end_idx ) ) )
                       code = code_lines ).
       add_finding(
-      exporting
+      EXPORTING
          procedure = procedure
          statement_index = statement_index
          code = message_codes-line_exists
          pseudo_comment = pseudo_comments-line_exists
          quickfixes = quickfixes
-      changing findings = findings ).
-    else.
+      CHANGING findings = findings ).
+    ELSE.
       add_finding(
-      exporting
+      EXPORTING
          procedure = procedure
          statement_index = statement_index
          code = message_codes-line_exists
          pseudo_comment = pseudo_comments-line_exists
-      changing findings = findings ).
-    endif.
+      CHANGING findings = findings ).
+    ENDIF.
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method analyze_loop.
-    data code_line_index type string.
-    data code_line_exists type string.
-    data code_lines type if_ci_atc_quickfix=>ty_code.
-    data key  type string.
+  METHOD analyze_loop.
+    DATA code_line_index TYPE string.
+    DATA code_line_exists TYPE string.
+    DATA code_lines TYPE if_ci_atc_quickfix=>ty_code.
+    DATA key  TYPE string.
 
-    data(statement) = procedure-statements[ statement_index ].
-    if analyzer->find_clause_index(  tokens = statement-tokens clause = 'OR' ) <> 0
-    or analyzer->find_clause_index(  tokens = statement-tokens clause = 'ASSIGNING' ) <> 0
-    or analyzer->find_clause_index(  tokens = statement-tokens clause = 'INITIAL' ) <> 0
-    or analyzer->find_clause_index(  tokens = statement-tokens clause = 'NOT' ) <> 0.
-      return.
-    endif.
-    data(key_idx) = analyzer->find_clause_index(  tokens = statement-tokens clause = 'WHERE' ).
-    if key_idx = 0 or statement-tokens[ key_idx + 1 ]-lexeme cp '(*'.
-      return.
-    endif.
-    data(table) = statement-tokens[ 3 ]-lexeme.
-    if table cp '*('.
-      return.
-    endif.
-    data(result_idx) = analyzer->find_clause_index( tokens = statement-tokens clause = 'INTO' ).
-    if result_idx <> 0.
-      assign statement-tokens[ result_idx + 1 ] to field-symbol(<token>).
-      if is_used( procedure = procedure from_index = statement_index + 1 full_name = <token>-references[ lines( <token>-references ) ]-full_name ).
-        return.
-      endif.
-    endif.
-    if analyzer->find_clause_index( tokens = statement-tokens start_index = key_idx + 1 clause = '(' ) <> 0
-    or analyzer->find_clause_index( tokens = statement-tokens start_index = key_idx + 1 clause = ')' ) <> 0.
-      return.
-    endif.
-    data(token_idx) = key_idx + 1.
-    do.
-      assign statement-tokens[ token_idx ] to <token>.
-      append_token( exporting token = <token> changing result = key ).
+    DATA(statement) = procedure-statements[ statement_index ].
+    IF analyzer->find_clause_index(  tokens = statement-tokens clause = 'OR' ) <> 0
+    OR analyzer->find_clause_index(  tokens = statement-tokens clause = 'ASSIGNING' ) <> 0
+    OR analyzer->find_clause_index(  tokens = statement-tokens clause = 'INITIAL' ) <> 0
+    OR analyzer->find_clause_index(  tokens = statement-tokens clause = 'NOT' ) <> 0.
+      RETURN.
+    ENDIF.
+    DATA(key_idx) = analyzer->find_clause_index(  tokens = statement-tokens clause = 'WHERE' ).
+    IF key_idx = 0 OR statement-tokens[ key_idx + 1 ]-lexeme CP '(*'.
+      RETURN.
+    ENDIF.
+    DATA(table) = statement-tokens[ 3 ]-lexeme.
+    IF table CP '*('.
+      RETURN.
+    ENDIF.
+    DATA(result_idx) = analyzer->find_clause_index( tokens = statement-tokens clause = 'INTO' ).
+    IF result_idx <> 0.
+      ASSIGN statement-tokens[ result_idx + 1 ] TO FIELD-SYMBOL(<token>).
+      IF is_used( procedure = procedure from_index = statement_index + 1 full_name = <token>-references[ lines( <token>-references ) ]-full_name ).
+        RETURN.
+      ENDIF.
+    ENDIF.
+    IF analyzer->find_clause_index( tokens = statement-tokens start_index = key_idx + 1 clause = '(' ) <> 0
+    OR analyzer->find_clause_index( tokens = statement-tokens start_index = key_idx + 1 clause = ')' ) <> 0.
+      RETURN.
+    ENDIF.
+    DATA(token_idx) = key_idx + 1.
+    DO.
+      ASSIGN statement-tokens[ token_idx ] TO <token>.
+      append_token( EXPORTING token = <token> CHANGING result = key ).
       token_idx += 1.
-      assign statement-tokens[ token_idx ] to <token>.
-      case <token>-lexeme.
-        when '=' or 'EQ'.
+      ASSIGN statement-tokens[ token_idx ] TO <token>.
+      CASE <token>-lexeme.
+        WHEN '=' OR 'EQ'.
           key = |{ key } = |.
-        when others.
-          return.
-      endcase.
-      data(and_idx) = analyzer->find_clause_index( tokens = statement-tokens start_index = token_idx + 1 clause = 'AND' ).
-      if and_idx = 0.
-        append_tokens( exporting tokens = statement-tokens from_idx = token_idx + 1 changing result = key ).
-        exit.
-      else.
-        append_tokens( exporting tokens = statement-tokens from_idx = token_idx + 1 to_idx = and_idx - 1 changing result = key ).
+        WHEN OTHERS.
+          RETURN.
+      ENDCASE.
+      DATA(and_idx) = analyzer->find_clause_index( tokens = statement-tokens start_index = token_idx + 1 clause = 'AND' ).
+      IF and_idx = 0.
+        append_tokens( EXPORTING tokens = statement-tokens from_idx = token_idx + 1 CHANGING result = key ).
+        EXIT.
+      ELSE.
+        append_tokens( EXPORTING tokens = statement-tokens from_idx = token_idx + 1 to_idx = and_idx - 1 CHANGING result = key ).
         token_idx = and_idx + 1.
-      endif.
-    enddo.
-    data(quickfixable) = abap_true.
-    loop at procedure-statements from statement_index + 1 assigning field-symbol(<statement>).
-      case <statement>-keyword.
-        when 'ENDLOOP'.
-          data(end_idx) = sy-tabix.
-          exit.
-        when 'EXIT'.
-          data(contains_exit) = abap_true.
-        when 'MOVE'.
-          if line_exists( <statement>-tokens[ lexeme = 'SY-TABIX' ] ).
+      ENDIF.
+    ENDDO.
+    DATA(quickfixable) = abap_true.
+    LOOP AT procedure-statements FROM statement_index + 1 ASSIGNING FIELD-SYMBOL(<statement>).
+      CASE <statement>-keyword.
+        WHEN 'ENDLOOP'.
+          DATA(end_idx) = sy-tabix.
+          EXIT.
+        WHEN 'EXIT'.
+          DATA(contains_exit) = abap_true.
+        WHEN 'MOVE'.
+          IF line_exists( <statement>-tokens[ lexeme = 'SY-TABIX' ] ).
             code_line_index = get_move_changed_line( <statement> ).
-            replace first occurrence of 'SY-TABIX' in code_line_index with |line_index( { table }[ { key } ] )| ##NO_TEXT.
-            append code_line_index to code_lines.
-          endif.
-        when 'MESSAGE' or 'PERFORM' or '+CALL_MACRO'.
-          if line_exists( <statement>-tokens[ lexeme = 'SY-TABIX' ] ).
+            REPLACE FIRST OCCURRENCE OF 'SY-TABIX' IN code_line_index WITH |line_index( { table }[ { key } ] )| ##NO_TEXT.
+            APPEND code_line_index TO code_lines.
+          ENDIF.
+        WHEN 'MESSAGE' OR 'PERFORM' OR '+CALL_MACRO'.
+          IF line_exists( <statement>-tokens[ lexeme = 'SY-TABIX' ] ).
             quickfixable = abap_false.
-            exit.
-          endif.
-        when 'SET'.
-          if line_exists( <statement>-tokens[ lexeme = 'SY-TABIX' ] )
-            and <statement>-tokens[ 2 ]-references is initial and <statement>-tokens[ 2 ]-lexeme = 'BIT'.
+            EXIT.
+          ENDIF.
+        WHEN 'SET'.
+          IF line_exists( <statement>-tokens[ lexeme = 'SY-TABIX' ] )
+            AND <statement>-tokens[ 2 ]-references IS INITIAL AND <statement>-tokens[ 2 ]-lexeme = 'BIT'.
             quickfixable = abap_false.
-          endif.
-        when others.
-          if line_exists( <statement>-tokens[ lexeme = 'SY-TABIX' ] ).
-            loop at <statement>-tokens assigning <token>.
-              if <token>-lexeme = 'SY-TABIX'.
+          ENDIF.
+        WHEN OTHERS.
+          IF line_exists( <statement>-tokens[ lexeme = 'SY-TABIX' ] ).
+            LOOP AT <statement>-tokens ASSIGNING <token>.
+              IF <token>-lexeme = 'SY-TABIX'.
                 code_line_index = |{ code_line_index } line_index( { table }[ { key } ] )| ##NO_TEXT.
-              elseif code_line_index is initial.
+              ELSEIF code_line_index IS INITIAL.
                 code_line_index = <token>-lexeme.
-              else.
+              ELSE.
                 code_line_index = |{ code_line_index } { <token>-lexeme }|.
-              endif.
-            endloop.
+              ENDIF.
+            ENDLOOP.
             code_line_index = |{ code_line_index }.|.
-            append code_line_index to code_lines.
-          else.
-            data(idx) = analyzer->find_clause_index( tokens = <statement>-tokens clause = '=' ).
-            if idx = 0 or <statement>-tokens[ idx + 1 ]-lexeme <> 'ABAP_TRUE'.
-              return.
-            endif.
-            loop at <statement>-tokens to idx - 1 assigning <token>.
-              if code_line_exists is initial.
+            APPEND code_line_index TO code_lines.
+          ELSE.
+            DATA(idx) = analyzer->find_clause_index( tokens = <statement>-tokens clause = '=' ).
+            IF idx = 0 OR <statement>-tokens[ idx + 1 ]-lexeme <> 'ABAP_TRUE'.
+              RETURN.
+            ENDIF.
+            LOOP AT <statement>-tokens TO idx - 1 ASSIGNING <token>.
+              IF code_line_exists IS INITIAL.
                 code_line_exists = <token>-lexeme.
-              else.
+              ELSE.
                 code_line_exists = |{ code_line_exists } { <token>-lexeme }|.
-              endif.
-            endloop.
+              ENDIF.
+            ENDLOOP.
             code_line_exists = |{ code_line_exists } = xsdbool( line_exists( { table }[ { key } ] ) ).| ##NO_TEXT.
-            append code_line_exists to code_lines.
-          endif.
-      endcase.
-    endloop.
-    if contains_exit = abap_true.
-      data quickfixes type ref to cl_ci_atc_quickfixes.
-      if quickfixable = abap_true.
+            APPEND code_line_exists TO code_lines.
+          ENDIF.
+      ENDCASE.
+    ENDLOOP.
+    IF contains_exit = abap_true.
+      DATA quickfixes TYPE REF TO cl_ci_atc_quickfixes.
+      IF quickfixable = abap_true.
         quickfixes = assistant_factory->create_quickfixes( ).
-        data(quickfix) = quickfixes->create_quickfix( quickfix_codes-line_exists ).
+        DATA(quickfix) = quickfixes->create_quickfix( quickfix_codes-line_exists ).
         quickfix->replace(
             context = assistant_factory->create_quickfix_context(
-               value #( procedure_id = procedure-id statements = value #( from = statement_index to = end_idx ) ) )
+               VALUE #( procedure_id = procedure-id statements = VALUE #( from = statement_index to = end_idx ) ) )
                         code = code_lines ).
-      endif.
+      ENDIF.
       add_finding(
-      exporting
+      EXPORTING
          procedure = procedure
          statement_index = statement_index
          code = message_codes-line_exists
          pseudo_comment = pseudo_comments-line_exists
          quickfixes = quickfixes
-      changing findings = findings ).
-    endif.
-  endmethod.
+      CHANGING findings = findings ).
+    ENDIF.
+  ENDMETHOD.
 
 
-  method analyze_create_object.
-    data code_line type string.
-    data(statement) = procedure-statements[ statement_index ].
-    data(replace_data) = abap_true.
+  METHOD analyze_create_object.
+    DATA code_line TYPE string.
+    DATA(statement) = procedure-statements[ statement_index ].
+    DATA(replace_data) = abap_true.
 
-    if analyzer->find_clause_index( tokens = statement-tokens clause = 'TYPE' ) <> 0
-    or analyzer->find_clause_index( tokens = statement-tokens clause = 'AREA HANDLE' ) <> 0
-    or analyzer->find_clause_index( tokens = statement-tokens clause = 'EXCEPTIONS' ) <> 0 "old exceptions cannot be handled with NEW
-    or analyzer->find_clause_index( tokens = statement-tokens clause = 'FOR TESTING' ) <> 0.
-      return.
-    endif.
+    IF analyzer->find_clause_index( tokens = statement-tokens clause = 'TYPE' ) <> 0
+    OR analyzer->find_clause_index( tokens = statement-tokens clause = 'AREA HANDLE' ) <> 0
+    OR analyzer->find_clause_index( tokens = statement-tokens clause = 'EXCEPTIONS' ) <> 0 "old exceptions cannot be handled with NEW
+    OR analyzer->find_clause_index( tokens = statement-tokens clause = 'FOR TESTING' ) <> 0.
+      RETURN.
+    ENDIF.
 
-    data(object_name) = statement-tokens[ 3 ]-lexeme.
-    data(full_name) = statement-tokens[ 3 ]-references[ lines( statement-tokens[ 3 ]-references ) ]-full_name.
+    DATA(object_name) = statement-tokens[ 3 ]-lexeme.
+    DATA(full_name) = statement-tokens[ 3 ]-references[ lines( statement-tokens[ 3 ]-references ) ]-full_name.
 *   self reference is working with create object but not with new
-    loop at statement-tokens assigning field-symbol(<token>) from 4 where lexeme cp |{ object_name }*| and references is not initial.
-      loop at <token>-references transporting no fields where full_name cp |{ full_name }*|.
+    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<token>) FROM 4 WHERE lexeme CP |{ object_name }*| AND references IS NOT INITIAL.
+      LOOP AT <token>-references TRANSPORTING NO FIELDS WHERE full_name CP |{ full_name }*|.
         replace_data = abap_false.
-        exit.
-      endloop.
-    endloop.
+        EXIT.
+      ENDLOOP.
+    ENDLOOP.
 *   find data statement
-    data(data_idx) = statement_index - 1.
-    while data_idx > 0.
-      if procedure-statements[ data_idx ]-keyword = 'DATA'
-      and procedure-statements[ data_idx ]-tokens[ 2 ]-lexeme = object_name.
-        assign procedure-statements[ data_idx ] to field-symbol(<statement>).
-        data(type_idx) = analyzer->find_clause_index( tokens = <statement>-tokens clause = 'TYPE REF TO' ).
-        if type_idx = 0.
-          return.
-        endif.
-        if replace_data = abap_true and data_idx = statement_index - 1.
-          data(type_name) = <statement>-tokens[ type_idx + 3 ]-lexeme.
+    DATA(data_idx) = statement_index - 1.
+    WHILE data_idx > 0.
+      IF procedure-statements[ data_idx ]-keyword = 'DATA'
+      AND procedure-statements[ data_idx ]-tokens[ 2 ]-lexeme = object_name.
+        ASSIGN procedure-statements[ data_idx ] TO FIELD-SYMBOL(<statement>).
+        DATA(type_idx) = analyzer->find_clause_index( tokens = <statement>-tokens clause = 'TYPE REF TO' ).
+        IF type_idx = 0.
+          RETURN.
+        ENDIF.
+        IF replace_data = abap_true AND data_idx = statement_index - 1.
+          DATA(type_name) = <statement>-tokens[ type_idx + 3 ]-lexeme.
           code_line = |DATA({ object_name }) = NEW { type_name }( |.
-          data(from_idx) = data_idx.
-        else.
+          DATA(from_idx) = data_idx.
+        ELSE.
           code_line = |{ object_name } = NEW #( |.
           from_idx = statement_index.
-        endif.
-      endif.
+        ENDIF.
+      ENDIF.
       data_idx -= 1.
-    endwhile.
-    if code_line is initial.
+    ENDWHILE.
+    IF code_line IS INITIAL.
       add_finding(
-      exporting
+      EXPORTING
          procedure = procedure
          statement_index = statement_index
          code = message_codes-prefer_new
          pseudo_comment = pseudo_comments-prefer_new
-      changing findings = findings ).
-      return.
-    endif.
-    data(exporting_idx) = analyzer->find_clause_index( tokens = statement-tokens clause = 'EXPORTING' ).
+      CHANGING findings = findings ).
+      RETURN.
+    ENDIF.
+    DATA(exporting_idx) = analyzer->find_clause_index( tokens = statement-tokens clause = 'EXPORTING' ).
 
-    data(quickfixes) = assistant_factory->create_quickfixes( ).
-    data(quickfix) = quickfixes->create_quickfix( quickfix_codes-prefer_new ).
-    if from_idx < statement_index.
+    DATA(quickfixes) = assistant_factory->create_quickfixes( ).
+    DATA(quickfix) = quickfixes->create_quickfix( quickfix_codes-prefer_new ).
+    IF from_idx < statement_index.
       quickfix->replace(
           context = assistant_factory->create_quickfix_context(
-             value #( procedure_id = procedure-id statements = value #( from = from_idx to = statement_index - 1 ) ) )
-                      code = value #( ( `` )  ) ).
-    endif.
-    if exporting_idx = 0.
-      data(to_idx) = 3.
-    else.
+             VALUE #( procedure_id = procedure-id statements = VALUE #( from = from_idx to = statement_index - 1 ) ) )
+                      code = VALUE #( ( `` )  ) ).
+    ENDIF.
+    IF exporting_idx = 0.
+      DATA(to_idx) = 3.
+    ELSE.
       to_idx = exporting_idx.
-    endif.
+    ENDIF.
     quickfix->replace(
         context = assistant_factory->create_quickfix_context(
-           value #( procedure_id = procedure-id
-                    statements = value #( from = statement_index to = statement_index )
-                    tokens = value #( from = 1 to = to_idx ) ) )
-                    code = value #( ( code_line )  ) ).
+           VALUE #( procedure_id = procedure-id
+                    statements = VALUE #( from = statement_index to = statement_index )
+                    tokens = VALUE #( from = 1 to = to_idx ) ) )
+                    code = VALUE #( ( code_line )  ) ).
     quickfix->insert_after(
     context = assistant_factory->create_quickfix_context(
-    value #( procedure_id = procedure-id
-        statements = value #( from = statement_index to = statement_index )
-        tokens = value #( from = lines( statement-tokens ) to = lines( statement-tokens ) ) ) )
-        code = value #( ( `)` )  ) ).
+    VALUE #( procedure_id = procedure-id
+        statements = VALUE #( from = statement_index to = statement_index )
+        tokens = VALUE #( from = lines( statement-tokens ) to = lines( statement-tokens ) ) ) )
+        code = VALUE #( ( `)` )  ) ).
 
     add_finding(
-    exporting
+    EXPORTING
        procedure = procedure
        statement_index = statement_index
        code = message_codes-prefer_new
        pseudo_comment = pseudo_comments-prefer_new
        quickfixes = quickfixes
-    changing findings = findings ).
-  endmethod.
+    CHANGING findings = findings ).
+  ENDMETHOD.
 
 
-  method analyze_call_method.
-    data code_line type string.
-    data(statement) = procedure-statements[ statement_index ].
-    if statement-tokens[ 3 ]-references is initial and statement-tokens[ 3 ]-lexeme = 'OF'. "ole
-      return.
-    endif.
-    data(method_name) = statement-tokens[ 3 ]-lexeme.
-    if method_name(1) = '(' or method_name cp '*->(*' or method_name cp '*=>(*' or method_name cp '(*)'
-      or analyzer->find_clause_index( tokens = statement-tokens clause = 'PARAMETER-TABLE' ) <> 0
-      or analyzer->find_clause_index( tokens = statement-tokens clause = 'EXCEPTION-TABLE' ) <> 0
-      or analyzer->find_clause_index( tokens = statement-tokens clause = 'EXCEPTIONS' ) <> 0.
+  METHOD analyze_call_method.
+    DATA code_line TYPE string.
+    DATA(statement) = procedure-statements[ statement_index ].
+    IF statement-tokens[ 3 ]-references IS INITIAL AND statement-tokens[ 3 ]-lexeme = 'OF'. "ole
+      RETURN.
+    ENDIF.
+    DATA(method_name) = statement-tokens[ 3 ]-lexeme.
+    IF method_name(1) = '(' OR method_name CP '*->(*' OR method_name CP '*=>(*' OR method_name CP '(*)'
+      OR analyzer->find_clause_index( tokens = statement-tokens clause = 'PARAMETER-TABLE' ) <> 0
+      OR analyzer->find_clause_index( tokens = statement-tokens clause = 'EXCEPTION-TABLE' ) <> 0
+      OR analyzer->find_clause_index( tokens = statement-tokens clause = 'EXCEPTIONS' ) <> 0.
 *     dynamic call / exceptions
-      return.
-    endif.
+      RETURN.
+    ENDIF.
 
-    if method_name np '*('.
-      data(method_line) = |{ method_name }(|.
-    else.
+    IF method_name NP '*('.
+      DATA(method_line) = |{ method_name }(|.
+    ELSE.
       method_line = method_name.
-    endif.
-    if  analyzer->find_clause_index( tokens = statement-tokens clause = 'IMPORTING' ) = 0
-    and analyzer->find_clause_index( tokens = statement-tokens clause = 'CHANGING' ) = 0 .
-      data(exporting_idx) = analyzer->find_clause_index( tokens = statement-tokens clause = 'EXPORTING' ).
-      data(receiving_infos) = get_receiving_infos( tokens = statement-tokens ).
-    endif.
-    data(quickfixes) = assistant_factory->create_quickfixes( ).
-    data(quickfix) = quickfixes->create_quickfix( quickfix_codes-call_method ).
-    if lines( statement-tokens ) = 3
-    or lines( statement-tokens ) = 4.
+    ENDIF.
+    IF  analyzer->find_clause_index( tokens = statement-tokens clause = 'IMPORTING' ) = 0
+    AND analyzer->find_clause_index( tokens = statement-tokens clause = 'CHANGING' ) = 0 .
+      DATA(exporting_idx) = analyzer->find_clause_index( tokens = statement-tokens clause = 'EXPORTING' ).
+      DATA(receiving_infos) = get_receiving_infos( tokens = statement-tokens ).
+    ENDIF.
+    DATA(quickfixes) = assistant_factory->create_quickfixes( ).
+    DATA(quickfix) = quickfixes->create_quickfix( quickfix_codes-call_method ).
+    IF lines( statement-tokens ) = 3
+    OR lines( statement-tokens ) = 4.
       quickfix->replace(
          context = assistant_factory->create_quickfix_context(
-            value #( procedure_id = procedure-id
-                     statements = value #( from = statement_index to = statement_index ) ) )
-         code = value #( ( |{  method_line } ).| ) ) ).
-    else.
-      if exporting_idx <> 0.
+            VALUE #( procedure_id = procedure-id
+                     statements = VALUE #( from = statement_index to = statement_index ) ) )
+         code = VALUE #( ( |{  method_line } ).| ) ) ).
+    ELSE.
+      IF exporting_idx <> 0.
         quickfix->replace(
           context = assistant_factory->create_quickfix_context(
-             value #( procedure_id = procedure-id
-                      statements = value #( from = statement_index to = statement_index )
-                      tokens = value #( from = exporting_idx to = exporting_idx ) ) )
-          code = value #( ( `` ) ) ).
-      endif.
-      if receiving_infos-result_line is not initial.
-        if receiving_infos-end_idx = lines( statement-tokens ).
+             VALUE #( procedure_id = procedure-id
+                      statements = VALUE #( from = statement_index to = statement_index )
+                      tokens = VALUE #( from = exporting_idx to = exporting_idx ) ) )
+          code = VALUE #( ( `` ) ) ).
+      ENDIF.
+      IF receiving_infos-result_line IS NOT INITIAL.
+        IF receiving_infos-end_idx = lines( statement-tokens ).
           code_line = ')'.
-        else.
+        ELSE.
           code_line = ''.
-        endif.
+        ENDIF.
         quickfix->replace(
            context = assistant_factory->create_quickfix_context(
-              value #( procedure_id = procedure-id
-                       statements = value #( from = statement_index to = statement_index )
-                       tokens = value #( from = receiving_infos-receiving_idx to = receiving_infos-end_idx ) ) )
-           code = value #( ( code_line ) ) ).
+              VALUE #( procedure_id = procedure-id
+                       statements = VALUE #( from = statement_index to = statement_index )
+                       tokens = VALUE #( from = receiving_infos-receiving_idx to = receiving_infos-end_idx ) ) )
+           code = VALUE #( ( code_line ) ) ).
         method_line = |{ receiving_infos-result_line } = { method_line }|.
-      endif.
+      ENDIF.
 
       quickfix->replace(
         context = assistant_factory->create_quickfix_context(
-           value #( procedure_id = procedure-id
-                    statements = value #( from = statement_index to = statement_index )
-                    tokens = value #( from = 1 to = 3 ) ) )
-        code = value #( ( method_line ) ) ).
+           VALUE #( procedure_id = procedure-id
+                    statements = VALUE #( from = statement_index to = statement_index )
+                    tokens = VALUE #( from = 1 to = 3 ) ) )
+        code = VALUE #( ( method_line ) ) ).
 
-      if receiving_infos-end_idx <> lines( statement-tokens ) and method_name np '*('.
+      IF receiving_infos-end_idx <> lines( statement-tokens ) AND method_name NP '*('.
         quickfix->insert_after(
           context = assistant_factory->create_quickfix_context(
-             value #( procedure_id = procedure-id
-                      statements = value #( from = statement_index to = statement_index )
-                      tokens = value #( from = lines( statement-tokens ) to = lines( statement-tokens ) ) ) )
-          code = value #( (  `)` ) ) ).
-      endif.
-    endif.
+             VALUE #( procedure_id = procedure-id
+                      statements = VALUE #( from = statement_index to = statement_index )
+                      tokens = VALUE #( from = lines( statement-tokens ) to = lines( statement-tokens ) ) ) )
+          code = VALUE #( (  `)` ) ) ).
+      ENDIF.
+    ENDIF.
     add_finding(
-    exporting
+    EXPORTING
        procedure = procedure
        statement_index = statement_index
        code = message_codes-call_method
        pseudo_comment = pseudo_comments-call_method
        quickfixes = quickfixes
-    changing findings = findings ).
-  endmethod.
+    CHANGING findings = findings ).
+  ENDMETHOD.
 
 
-  method analyze_exporting_receiving.
-    data exporting_idxs type sorted table of i with unique key table_line.
-    data(statement) = procedure-statements[ statement_index ].
-    if analyzer->find_clause_index( tokens = statement-tokens clause = 'EXCEPTIONS' ) <> 0
-    or analyzer->find_clause_index( tokens = statement-tokens clause = 'IMPORTING' ) <> 0
-    or analyzer->find_clause_index( tokens = statement-tokens clause = 'CHANGING' ) <> 0.
-      return.
-    endif.
-    loop at statement-tokens assigning field-symbol(<token>) where references is initial and lexeme = 'EXPORTING'.
-      data(token_idx) = sy-tabix.
-      if check_remove_exporting( statement = statement token_idx = token_idx ) = abap_true.
-        insert token_idx into table exporting_idxs.
-      endif.
-    endloop.
+  METHOD analyze_exporting_receiving.
+    DATA exporting_idxs TYPE SORTED TABLE OF i WITH UNIQUE KEY table_line.
+    DATA(statement) = procedure-statements[ statement_index ].
+    IF analyzer->find_clause_index( tokens = statement-tokens clause = 'EXCEPTIONS' ) <> 0
+    OR analyzer->find_clause_index( tokens = statement-tokens clause = 'IMPORTING' ) <> 0
+    OR analyzer->find_clause_index( tokens = statement-tokens clause = 'CHANGING' ) <> 0.
+      RETURN.
+    ENDIF.
+    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<token>) WHERE references IS INITIAL AND lexeme = 'EXPORTING'.
+      DATA(token_idx) = sy-tabix.
+      IF check_remove_exporting( statement = statement token_idx = token_idx ) = abap_true.
+        INSERT token_idx INTO TABLE exporting_idxs.
+      ENDIF.
+    ENDLOOP.
 
-    data(receiving_infos) = get_receiving_infos( tokens = statement-tokens ).
+    DATA(receiving_infos) = get_receiving_infos( tokens = statement-tokens ).
 
-    if receiving_infos-result_line is initial and exporting_idxs is initial.
-      return.
-    endif.
-    data(quickfixes) = assistant_factory->create_quickfixes( ).
-    data pseudo_comment type string.
-    if receiving_infos-result_line is not initial.
-      data(finding_code) = message_codes-exporting_receiving.
+    IF receiving_infos-result_line IS INITIAL AND exporting_idxs IS INITIAL.
+      RETURN.
+    ENDIF.
+    DATA(quickfixes) = assistant_factory->create_quickfixes( ).
+    DATA pseudo_comment TYPE string.
+    IF receiving_infos-result_line IS NOT INITIAL.
+      DATA(finding_code) = message_codes-exporting_receiving.
       pseudo_comment = pseudo_comments-exporting_receiving.
-      data(quickfix) = quickfixes->create_quickfix( quickfix_codes-exporting_receiving ).
+      DATA(quickfix) = quickfixes->create_quickfix( quickfix_codes-exporting_receiving ).
       receiving_infos-result_line = |{ receiving_infos-result_line } = { statement-tokens[ 1 ]-lexeme }|.
       quickfix->replace( context = assistant_factory->create_quickfix_context(
-            value #( procedure_id = procedure-id
-                     statements = value #( from = statement_index to = statement_index )
-                     tokens = value #( from = 1 to = 1 ) ) )
-            code = value #( ( receiving_infos-result_line ) ) ).
+            VALUE #( procedure_id = procedure-id
+                     statements = VALUE #( from = statement_index to = statement_index )
+                     tokens = VALUE #( from = 1 to = 1 ) ) )
+            code = VALUE #( ( receiving_infos-result_line ) ) ).
       quickfix->replace(
           context = assistant_factory->create_quickfix_context(
-              value #( procedure_id = procedure-id
-                       statements = value #( from = statement_index to = statement_index )
-                       tokens = value #( from = receiving_infos-receiving_idx to = receiving_infos-end_idx ) ) )
-              code = value #( ( `` ) ) ).
-    else.
+              VALUE #( procedure_id = procedure-id
+                       statements = VALUE #( from = statement_index to = statement_index )
+                       tokens = VALUE #( from = receiving_infos-receiving_idx to = receiving_infos-end_idx ) ) )
+              code = VALUE #( ( `` ) ) ).
+    ELSE.
       finding_code = message_codes-method_exporting.
       pseudo_comment = pseudo_comments-method_exporting.
       quickfix = quickfixes->create_quickfix( quickfix_codes-method_exporting ).
-    endif.
-    loop at exporting_idxs into data(exporting_idx).
+    ENDIF.
+    LOOP AT exporting_idxs INTO DATA(exporting_idx).
       quickfix->replace(
           context = assistant_factory->create_quickfix_context(
-              value #( procedure_id = procedure-id
-                       statements = value #( from = statement_index to = statement_index )
-                       tokens = value #( from = exporting_idx to = exporting_idx + 1 ) ) )
-              code = value #( ( statement-tokens[ exporting_idx + 1 ]-lexeme ) ) ).
-    endloop.
+              VALUE #( procedure_id = procedure-id
+                       statements = VALUE #( from = statement_index to = statement_index )
+                       tokens = VALUE #( from = exporting_idx to = exporting_idx + 1 ) ) )
+              code = VALUE #( ( statement-tokens[ exporting_idx + 1 ]-lexeme ) ) ).
+    ENDLOOP.
     add_finding(
-    exporting
+    EXPORTING
        procedure = procedure
        statement_index = statement_index
        code = finding_code
        pseudo_comment = pseudo_comment
        quickfixes = quickfixes
-    changing findings = findings ).
-  endmethod.
+    CHANGING findings = findings ).
+  ENDMETHOD.
 
 
-  method analyze_text_assembly.
+  METHOD analyze_text_assembly.
 
-    data(statement) = procedure-statements[ statement_index ].
+    DATA(statement) = procedure-statements[ statement_index ].
 
-    data start_idx type i.
-    data end_idx type i.
-    data last_idx type i.
-    data code_line type string.
-    data(quickfixes) = assistant_factory->create_quickfixes( ).
-    data(quickfix) = quickfixes->create_quickfix( quickfix_codes-text_assembly ).
-    data(quickfixable) = abap_true.
-    try.
-        loop at statement-tokens assigning field-symbol(<token>) where lexeme = '&&'.
-          data(tabix) = sy-tabix.
-          if tabix - 1 <> last_idx.
-            if code_line is not initial.
+    DATA start_idx TYPE i.
+    DATA end_idx TYPE i.
+    DATA last_idx TYPE i.
+    DATA code_line TYPE string.
+    DATA(quickfixes) = assistant_factory->create_quickfixes( ).
+    DATA(quickfix) = quickfixes->create_quickfix( quickfix_codes-text_assembly ).
+    DATA(quickfixable) = abap_true.
+    TRY.
+        LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<token>) WHERE lexeme = '&&'.
+          DATA(tabix) = sy-tabix.
+          IF tabix - 1 <> last_idx.
+            IF code_line IS NOT INITIAL.
 *             store old code_line
               code_line = |{ code_line }\||.
-              if strlen( code_line ) >= analyzer->max_line_length - 1.
+              IF strlen( code_line ) >= analyzer->max_line_length - 1.
                 quickfixable = abap_false.
-                exit.
-              else.
+                EXIT.
+              ELSE.
                 quickfix->replace(
                     context = assistant_factory->create_quickfix_context(
-                       value #( procedure_id = procedure-id
-                                statements = value #( from = statement_index to = statement_index )
-                                tokens = value #( from = start_idx to = end_idx ) ) )
-                    code = value #( ( code_line ) ) ).
-              endif.
-            endif.
+                       VALUE #( procedure_id = procedure-id
+                                statements = VALUE #( from = statement_index to = statement_index )
+                                tokens = VALUE #( from = start_idx to = end_idx ) ) )
+                    code = VALUE #( ( code_line ) ) ).
+              ENDIF.
+            ENDIF.
 *           new && connection
             code_line = '|'.
             start_idx = tabix - 1.
-            data(value) = get_value( statement-tokens[ tabix - 1 ] ).
+            DATA(value) = get_value( statement-tokens[ tabix - 1 ] ).
             code_line = |{ code_line }{ value }|.
-          endif.
+          ENDIF.
           value = get_value( statement-tokens[ tabix + 1 ] ).
           code_line = |{ code_line }{ value }|.
           end_idx = tabix + 1.
           last_idx = tabix + 1.
-        endloop.
-        if quickfixable = abap_true and code_line is not initial.
+        ENDLOOP.
+        IF quickfixable = abap_true AND code_line IS NOT INITIAL.
           code_line = |{ code_line }\||.
-          if strlen( code_line ) >= analyzer->max_line_length - 1.
+          IF strlen( code_line ) >= analyzer->max_line_length - 1.
             quickfixable = abap_false.
-          else.
+          ELSE.
             quickfix->replace(
                 context = assistant_factory->create_quickfix_context(
-                   value #( procedure_id = procedure-id
-                            statements = value #( from = statement_index to = statement_index )
-                            tokens = value #( from = start_idx to = end_idx ) ) )
-                code = value #( ( code_line ) ) ).
-          endif.
-        endif.
-      catch lcx_error.
+                   VALUE #( procedure_id = procedure-id
+                            statements = VALUE #( from = statement_index to = statement_index )
+                            tokens = VALUE #( from = start_idx to = end_idx ) ) )
+                code = VALUE #( ( code_line ) ) ).
+          ENDIF.
+        ENDIF.
+      CATCH lcx_error.
         quickfixable = abap_false.
-    endtry.
-    if quickfixable = abap_false.
-      clear quickfixes.
-    endif.
+    ENDTRY.
+    IF quickfixable = abap_false.
+      CLEAR quickfixes.
+    ENDIF.
     add_finding(
-    exporting
+    EXPORTING
        procedure = procedure
        statement_index = statement_index
        code = message_codes-text_assembly
        pseudo_comment = pseudo_comments-text_assembly
        quickfixes = quickfixes
-    changing findings = findings ).
+    CHANGING findings = findings ).
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method analyze_procedure.
+  METHOD analyze_procedure.
 
-    loop at procedure-statements assigning field-symbol(<statement>).
-      data(idx) = sy-tabix.
-      case <statement>-keyword.
-        when 'MOVE'.
-          insert lines of analyze_move( procedure = procedure statement_index = idx ) into table findings.
-        when 'TRANSLATE'.
-          insert lines of analyze_translate( procedure = procedure statement_index = idx ) into table findings.
-        when 'READ'.
-          insert lines of analyze_read( procedure = procedure statement_index = idx ) into table findings.
-        when 'LOOP'.
-          insert lines of analyze_loop( procedure = procedure statement_index = idx ) into table findings.
-        when 'CREATE'.
-          if <statement>-tokens[ 2 ]-lexeme = 'OBJECT' and <statement>-tokens[ 2 ]-references is initial.
-            insert lines of analyze_create_object( procedure = procedure statement_index = idx ) into table findings.
-          endif.
-        when 'CALL'.
-          if <statement>-tokens[ 2 ]-lexeme = 'METHOD' and <statement>-tokens[ 2 ]-references is initial.
-            insert lines of analyze_call_method( procedure = procedure statement_index = idx ) into table findings.
-          endif.
-        when 'METHODS' or 'CLASS-METHODS'.
-          continue.
-      endcase.
+    LOOP AT procedure-statements ASSIGNING FIELD-SYMBOL(<statement>).
+      DATA(idx) = sy-tabix.
+      CASE <statement>-keyword.
+        WHEN 'MOVE'.
+          INSERT LINES OF analyze_move( procedure = procedure statement_index = idx ) INTO TABLE findings.
+        WHEN 'TRANSLATE'.
+          INSERT LINES OF analyze_translate( procedure = procedure statement_index = idx ) INTO TABLE findings.
+        WHEN 'READ'.
+          INSERT LINES OF analyze_read( procedure = procedure statement_index = idx ) INTO TABLE findings.
+        WHEN 'LOOP'.
+          INSERT LINES OF analyze_loop( procedure = procedure statement_index = idx ) INTO TABLE findings.
+        WHEN 'CREATE'.
+          IF <statement>-tokens[ 2 ]-lexeme = 'OBJECT' AND <statement>-tokens[ 2 ]-references IS INITIAL.
+            INSERT LINES OF analyze_create_object( procedure = procedure statement_index = idx ) INTO TABLE findings.
+          ENDIF.
+        WHEN 'CALL'.
+          IF <statement>-tokens[ 2 ]-lexeme = 'METHOD' AND <statement>-tokens[ 2 ]-references IS INITIAL.
+            INSERT LINES OF analyze_call_method( procedure = procedure statement_index = idx ) INTO TABLE findings.
+          ENDIF.
+        WHEN 'METHODS' OR 'CLASS-METHODS'.
+          CONTINUE.
+      ENDCASE.
 *     functional method call may occur in many statements
-      if <statement>-keyword <> 'CALL' and <statement>-keyword <> 'CREATE'
-      and analyzer->find_clause_index( tokens = <statement>-tokens clause = 'EXPORTING' ) <> 0.
-        insert lines of analyze_exporting_receiving( procedure = procedure statement_index = idx  ) into table findings.
-      endif.
+      IF <statement>-keyword <> 'CALL' AND <statement>-keyword <> 'CREATE'
+      AND analyzer->find_clause_index( tokens = <statement>-tokens clause = 'EXPORTING' ) <> 0.
+        INSERT LINES OF analyze_exporting_receiving( procedure = procedure statement_index = idx  ) INTO TABLE findings.
+      ENDIF.
 *     text assembly
-      if analyzer->find_clause_index( tokens = <statement>-tokens clause = '&&' ) <> 0
-      and <statement>-keyword <> 'CONCATENATE'
-      and <statement>-keyword <> 'SPLIT'
-      and analyzer->is_db_statement( statement = <statement> ) is initial.
-        insert lines of analyze_text_assembly( procedure = procedure statement_index = idx ) into table findings.
-      endif.
-    endloop.
-  endmethod.
+      IF analyzer->find_clause_index( tokens = <statement>-tokens clause = '&&' ) <> 0
+      AND <statement>-keyword <> 'CONCATENATE'
+      AND <statement>-keyword <> 'SPLIT'
+      AND analyzer->is_db_statement( statement = <statement> ) IS INITIAL.
+        INSERT LINES OF analyze_text_assembly( procedure = procedure statement_index = idx ) INTO TABLE findings.
+      ENDIF.
+    ENDLOOP.
+  ENDMETHOD.
 
 
-  method is_used.
+  METHOD is_used.
     result = abap_false.
-    loop at procedure-statements from from_index assigning field-symbol(<statement>).
-      loop at <statement>-tokens assigning field-symbol(<token>)
-      where references is not initial.
+    LOOP AT procedure-statements FROM from_index ASSIGNING FIELD-SYMBOL(<statement>).
+      LOOP AT <statement>-tokens ASSIGNING FIELD-SYMBOL(<token>)
+      WHERE references IS NOT INITIAL.
         result = xsdbool( line_exists(  <token>-references[ full_name = full_name ] ) ).
-        if result = abap_true.
-          return.
-        endif.
-      endloop.
-    endloop.
-  endmethod.
+        IF result = abap_true.
+          RETURN.
+        ENDIF.
+      ENDLOOP.
+    ENDLOOP.
+  ENDMETHOD.
 
 
-  method check_remove_exporting.
+  METHOD check_remove_exporting.
     result = abap_false.
-    assign statement-tokens[ token_idx - 1 ] to field-symbol(<token>).
-    if not <token>-lexeme cp '*('.
-      return.
-    endif.
-    loop at <token>-references assigning field-symbol(<ref>)
-      where  kind = if_ci_atc_source_code_provider=>compiler_reference_kinds-method
-      and usage_grade <> if_ci_atc_source_code_provider=>usage_grades-definition.
-      data(is_method_call) = abap_true.
-      exit.
-    endloop.
-    if is_method_call = abap_false.
-      return.
-    endif.
-    if analyzer->find_clause_index( tokens = statement-tokens clause = 'IMPORTING' ) <> 0
-    or analyzer->find_clause_index( tokens = statement-tokens clause = 'CHANGING' ) <> 0.
-      return.
-    endif.
+    ASSIGN statement-tokens[ token_idx - 1 ] TO FIELD-SYMBOL(<token>).
+    IF NOT <token>-lexeme CP '*('.
+      RETURN.
+    ENDIF.
+    LOOP AT <token>-references ASSIGNING FIELD-SYMBOL(<ref>)
+      WHERE  kind = if_ci_atc_source_code_provider=>compiler_reference_kinds-method
+      AND usage_grade <> if_ci_atc_source_code_provider=>usage_grades-definition.
+      DATA(is_method_call) = abap_true.
+      EXIT.
+    ENDLOOP.
+    IF is_method_call = abap_false.
+      RETURN.
+    ENDIF.
+    IF analyzer->find_clause_index( tokens = statement-tokens clause = 'IMPORTING' ) <> 0
+    OR analyzer->find_clause_index( tokens = statement-tokens clause = 'CHANGING' ) <> 0.
+      RETURN.
+    ENDIF.
     result = abap_true.
-  endmethod.
+  ENDMETHOD.
 
 
-  method get_value.
-    if token-lexeme cp '*('
-    or token-lexeme cp '*['
-    or token-lexeme(1) = ']'
-    or token-lexeme(1) = ')'.
-      raise exception type lcx_error.
-    endif.
+  METHOD get_value.
+    IF token-lexeme CP '*('
+    OR token-lexeme CP '*['
+    OR token-lexeme(1) = ']'
+    OR token-lexeme(1) = ')'.
+      RAISE EXCEPTION TYPE lcx_error.
+    ENDIF.
 
-    if token-references is initial.
-      case token-lexeme.
-        when ')' or '|'.
-          raise exception type lcx_error.
-        when others.
-          if token-lexeme cp '`*`' or token-lexeme cp `'*'`.
-            data(len) = strlen( token-lexeme ) - 2.
+    IF token-references IS INITIAL.
+      CASE token-lexeme.
+        WHEN ')' OR '|'.
+          RAISE EXCEPTION TYPE lcx_error.
+        WHEN OTHERS.
+          IF token-lexeme CP '`*`' OR token-lexeme CP `'*'`.
+            DATA(len) = strlen( token-lexeme ) - 2.
             result = token-lexeme+1(len).
-            if result ca '|'.
-              raise exception type lcx_error.
-            endif.
+            IF result CA '|'.
+              RAISE EXCEPTION TYPE lcx_error.
+            ENDIF.
             result = replace( val = result sub = '\' with = '\\' occ = 0 ).
             result = replace( val = result sub = '{' with = '\{' occ = 0 ).
             result = replace( val = result sub = '}' with = '\}' occ = 0 ).
-          else.
-            raise exception type lcx_error.
-          endif.
-      endcase.
-    else.
-      if token-lexeme = 'NEW'.
-        raise exception type lcx_error.
-      endif.
+          ELSE.
+            RAISE EXCEPTION TYPE lcx_error.
+          ENDIF.
+      ENDCASE.
+    ELSE.
+      IF token-lexeme = 'NEW'.
+        RAISE EXCEPTION TYPE lcx_error.
+      ENDIF.
       result = |\{ { token-lexeme } \}|.
-    endif.
-  endmethod.
+    ENDIF.
+  ENDMETHOD.
 
 
-  method append_token.
-    if result is initial.
+  METHOD append_token.
+    IF result IS INITIAL.
       result = token-lexeme.
-    else.
+    ELSE.
       result = |{ result } { token-lexeme }|.
-    endif.
-  endmethod.
+    ENDIF.
+  ENDMETHOD.
 
 
-  method append_tokens.
-    data itab like tokens.
-    if from_idx is supplied or to_idx is supplied.
-      if from_idx = 0.
+  METHOD append_tokens.
+    DATA itab LIKE tokens.
+    IF from_idx IS SUPPLIED OR to_idx IS SUPPLIED.
+      IF from_idx = 0.
         from_idx = 1.
-      endif.
-      if to_idx = 0.
+      ENDIF.
+      IF to_idx = 0.
         to_idx = lines( tokens ).
-      endif.
-      loop at tokens from from_idx to to_idx assigning field-symbol(<token>).
-        append <token> to itab.
-      endloop.
-      data(flattened) = analyzer->flatten_tokens( tokens = itab ).
-    else.
+      ENDIF.
+      LOOP AT tokens FROM from_idx TO to_idx ASSIGNING FIELD-SYMBOL(<token>).
+        APPEND <token> TO itab.
+      ENDLOOP.
+      DATA(flattened) = analyzer->flatten_tokens( tokens = itab ).
+    ELSE.
       flattened = analyzer->flatten_tokens( tokens = tokens ).
-    endif.
-    if result is initial.
+    ENDIF.
+    IF result IS INITIAL.
       result = flattened.
-    else.
+    ELSE.
       result = |{ result } { flattened }|.
-    endif.
-  endmethod.
+    ENDIF.
+  ENDMETHOD.
 
 
-  method get_receiving_infos.
-    clear result-end_idx.
-    clear result-result_line.
+  METHOD get_receiving_infos.
+    CLEAR result-end_idx.
+    CLEAR result-result_line.
     result-receiving_idx = analyzer->find_clause_index( tokens = tokens clause = 'RECEIVING ' ).
-    if result-receiving_idx = 0.
-      return.
-    endif.
-    data(copy_idx) = analyzer->find_clause_index(  tokens = tokens start_index = result-receiving_idx + 1 clause = '=' ).
-    if copy_idx <> 0.
+    IF result-receiving_idx = 0.
+      RETURN.
+    ENDIF.
+    DATA(copy_idx) = analyzer->find_clause_index(  tokens = tokens start_index = result-receiving_idx + 1 clause = '=' ).
+    IF copy_idx <> 0.
       result-end_idx = lines( tokens ).
-      loop at tokens from copy_idx + 1 assigning field-symbol(<token>)
-      where references is initial.
-        case <token>-lexeme.
-          when ')' or 'EXPORTING'.
+      LOOP AT tokens FROM copy_idx + 1 ASSIGNING FIELD-SYMBOL(<token>)
+      WHERE references IS INITIAL.
+        CASE <token>-lexeme.
+          WHEN ')' OR 'EXPORTING'.
             result-end_idx = sy-tabix - 1.
-            exit.
-        endcase.
-      endloop.
-      append_tokens( exporting tokens = tokens from_idx = copy_idx + 1 to_idx = result-end_idx changing result = result-result_line ).
-    endif.
+            EXIT.
+        ENDCASE.
+      ENDLOOP.
+      append_tokens( EXPORTING tokens = tokens from_idx = copy_idx + 1 to_idx = result-end_idx CHANGING result = result-result_line ).
+    ENDIF.
 
-  endmethod.
-endclass.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/checks/#cc4a#modern_language.clas.testclasses.abap
+++ b/src/checks/#cc4a#modern_language.clas.testclasses.abap
@@ -1,78 +1,78 @@
-class test definition final for testing
-  duration short
-  risk level harmless.
+CLASS test DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
 
-  private section.
-    constants test_class type c length 30 value '/CC4A/TEST_MODERN_LANGUAGE'.
-    methods test for testing raising cx_static_check.
-endclass.
-class /cc4a/modern_language definition local friends test.
+  PRIVATE SECTION.
+    CONSTANTS test_class TYPE c LENGTH 30 VALUE '/CC4A/TEST_MODERN_LANGUAGE'.
+    METHODS test FOR TESTING RAISING cx_static_check.
+ENDCLASS.
+CLASS /cc4a/modern_language DEFINITION LOCAL FRIENDS test.
 
-class test implementation.
+CLASS test IMPLEMENTATION.
 
-  method test.
-    data(test_translate) = cl_ci_atc_unit_driver=>get_method_object( value #( class = test_class method = 'TEST_TRANSLATE' ) ).
-    data(test_read) = cl_ci_atc_unit_driver=>get_method_object( value #( class = test_class method = 'TEST_READ' ) ).
-    data(test_loop) = cl_ci_atc_unit_driver=>get_method_object( value #( class = test_class method = 'TEST_LOOP' ) ).
-    data(test_create_object) = cl_ci_atc_unit_driver=>get_method_object( value #( class = test_class method = 'TEST_CREATE_OBJECT' ) ).
-    data(test_call_method) = cl_ci_atc_unit_driver=>get_method_object( value #( class = test_class method = 'TEST_CALL_METHOD' ) ).
-    data(test_exporting_receiving) = cl_ci_atc_unit_driver=>get_method_object( value #( class = test_class method = 'TEST_EXPORTING_RECEIVING' ) ).
-    data(test_text_assembly) = cl_ci_atc_unit_driver=>get_method_object( value #( class = test_class method = 'TEST_TEXT_ASSEMBLY' ) ).
+  METHOD test.
+    DATA(test_translate) = cl_ci_atc_unit_driver=>get_method_object( VALUE #( class = test_class method = 'TEST_TRANSLATE' ) ).
+    DATA(test_read) = cl_ci_atc_unit_driver=>get_method_object( VALUE #( class = test_class method = 'TEST_READ' ) ).
+    DATA(test_loop) = cl_ci_atc_unit_driver=>get_method_object( VALUE #( class = test_class method = 'TEST_LOOP' ) ).
+    DATA(test_create_object) = cl_ci_atc_unit_driver=>get_method_object( VALUE #( class = test_class method = 'TEST_CREATE_OBJECT' ) ).
+    DATA(test_call_method) = cl_ci_atc_unit_driver=>get_method_object( VALUE #( class = test_class method = 'TEST_CALL_METHOD' ) ).
+    DATA(test_exporting_receiving) = cl_ci_atc_unit_driver=>get_method_object( VALUE #( class = test_class method = 'TEST_EXPORTING_RECEIVING' ) ).
+    DATA(test_text_assembly) = cl_ci_atc_unit_driver=>get_method_object( VALUE #( class = test_class method = 'TEST_TEXT_ASSEMBLY' ) ).
     cl_ci_atc_unit_driver=>create_test_case(
-      check = new /cc4a/modern_language( )
-      object = value #( type = 'CLAS' name = test_class )
-    )->execute_and_assert( value #(
+      check = NEW /cc4a/modern_language( )
+      object = VALUE #( type = 'CLAS' name = test_class )
+    )->execute_and_assert( VALUE #(
 
 *      TRANSLATE
      ( code = /cc4a/modern_language=>message_codes-translate
-       location = value #( object = test_translate position = value #( line = 3 column = 4 ) ) )
+       location = VALUE #( object = test_translate position = VALUE #( line = 3 column = 4 ) ) )
      ( code = /cc4a/modern_language=>message_codes-translate
-       location = value #( object = test_translate position = value #( line = 4 column = 4 ) ) )
+       location = VALUE #( object = test_translate position = VALUE #( line = 4 column = 4 ) ) )
      ( code = /cc4a/modern_language=>message_codes-translate
-       location = value #( object = test_translate position = value #( line = 5 column = 4 ) )
+       location = VALUE #( object = test_translate position = VALUE #( line = 5 column = 4 ) )
        has_pseudo_comment = abap_true )
 
 *       READ
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 4 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_read position = VALUE #( line = 4 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_read from = 4 to = 5 )
-         code_lines = value #( ( `DATA(IDX) = LINE_INDEX( ITAB[ PGMID = 'R3TR' OBJECT = 'CLAS' ] ).` ) ) ) ) )
+         span = VALUE #( object = test_read from = 4 to = 5 )
+         code_lines = VALUE #( ( `DATA(IDX) = LINE_INDEX( ITAB[ PGMID = 'R3TR' OBJECT = 'CLAS' ] ).` ) ) ) ) )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 7 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_read position = VALUE #( line = 7 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_read from = 7 to = 11 )
-         code_lines = value #( ( `IDX = LINE_INDEX( ITAB[ PGMID = 'R3TR' OBJECT = 'CLAS' ] ).` )
+         span = VALUE #( object = test_read from = 7 to = 11 )
+         code_lines = VALUE #( ( `IDX = LINE_INDEX( ITAB[ PGMID = 'R3TR' OBJECT = 'CLAS' ] ).` )
                                ( `DATA(EXISTS) = XSDBOOL( LINE_EXISTS( ITAB[ PGMID = 'R3TR' OBJECT = 'CLAS' ] ) ).` ) ) ) ) )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 19 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_read position = VALUE #( line = 19 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_read from = 19 to = 20 )
-         code_lines = value #( ( `IDX = LINE_INDEX( ITAB[ KEY NAME COMPONENTS OBJ_NAME = 'BLABLA' ] ).` ) ) ) ) )
+         span = VALUE #( object = test_read from = 19 to = 20 )
+         code_lines = VALUE #( ( `IDX = LINE_INDEX( ITAB[ KEY NAME COMPONENTS OBJ_NAME = 'BLABLA' ] ).` ) ) ) ) )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 21 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_read position = VALUE #( line = 21 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_read from = 21 to = 25 )
-         code_lines = value #( ( `EXISTS = XSDBOOL( LINE_EXISTS( ITAB[ KEY NAME COMPONENTS OBJ_NAME = 'BLABLA' ] ) ).` )
+         span = VALUE #( object = test_read from = 21 to = 25 )
+         code_lines = VALUE #( ( `EXISTS = XSDBOOL( LINE_EXISTS( ITAB[ KEY NAME COMPONENTS OBJ_NAME = 'BLABLA' ] ) ).` )
                                ( `IDX = LINE_INDEX( ITAB[ KEY NAME COMPONENTS OBJ_NAME = 'BLABLA' ] ).` ) ) ) ) )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 27 column = 4 ) )
+       location = VALUE #( object = test_read position = VALUE #( line = 27 column = 4 ) )
        has_pseudo_comment = abap_true  )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 34 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_read position = VALUE #( line = 34 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_read from = 34 to = 35 )
-         code_lines = value #( ( `IDX = line_index( ITAB[ PGMID = 'R3TR' ] ).` ) ) ) ) )
+         span = VALUE #( object = test_read from = 34 to = 35 )
+         code_lines = VALUE #( ( `IDX = line_index( ITAB[ PGMID = 'R3TR' ] ).` ) ) ) ) )
 
 *     ( code = /cc4a/modern_language=>message_codes-move
 *       location = VALUE #( object = test_read position = VALUE #( line = 35 column = 4 ) )
@@ -82,190 +82,204 @@ class test implementation.
 *         code_lines = VALUE #( ( `idx = sy-tabix.` ) ) ) ) )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 37 column = 4 ) )
+       location = VALUE #( object = test_read position = VALUE #( line = 37 column = 4 ) )
        has_pseudo_comment = abap_true  )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 41 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_read position = VALUE #( line = 41 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_read from = 41 to = 44 )
-         code_lines = value #( ( `DATA(BLUE) = xsdbool( NOT line_exists( ITAB[ KEY NAME COMPONENTS OBJ_NAME = 'BLUE' ] ) ).` ) ) ) ) )
+         span = VALUE #( object = test_read from = 41 to = 44 )
+         code_lines = VALUE #( ( `DATA(BLUE) = xsdbool( NOT line_exists( ITAB[ KEY NAME COMPONENTS OBJ_NAME = 'BLUE' ] ) ).` ) ) ) ) )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 46 column = 4 ) )
+       location = VALUE #( object = test_read position = VALUE #( line = 46 column = 4 ) )
        has_pseudo_comment = abap_true  )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 52 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_read position = VALUE #( line = 52 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_read from = 52 to = 54 )
-         code_lines = value #( ( `IF  line_index( ITAB[ PGMID  =  'R3TR'  ] ) =  0 .` ) ) ) ) )
+         span = VALUE #( object = test_read from = 52 to = 54 )
+         code_lines = VALUE #( ( `IF  line_index( ITAB[ PGMID  =  'R3TR'  ] ) =  0 .` ) ) ) ) )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 57 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_read position = VALUE #( line = 57 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_read from = 57 to = 59 )
-         code_lines = value #( ( `IF  line_index( ITAB[ PGMID  =  'R3TR'  ] ) =  0 .` ) ) ) ) )
+         span = VALUE #( object = test_read from = 57 to = 59 )
+         code_lines = VALUE #( ( `IF  line_index( ITAB[ PGMID  =  'R3TR'  ] ) =  0 .` ) ) ) ) )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 62 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_read position = VALUE #( line = 62 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_read from = 62 to = 64 )
-         code_lines = value #( ( `IF  line_index( ITAB[ PGMID  =  'R3TR'  ] ) <>  0 .` ) ) ) ) )
+         span = VALUE #( object = test_read from = 62 to = 64 )
+         code_lines = VALUE #( ( `IF  line_index( ITAB[ PGMID  =  'R3TR'  ] ) <>  0 .` ) ) ) ) )
 
 
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 67 column = 4 ) )
+       location = VALUE #( object = test_read position = VALUE #( line = 67 column = 4 ) )
        has_pseudo_comment = abap_true
-       quickfixes = value #( (
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_read from = 67 to = 69 )
-         code_lines = value #( ( `IF  line_index( ITAB[ PGMID  =  'R3TR'  ] ) <>  0 .` ) ) ) ) )
+         span = VALUE #( object = test_read from = 67 to = 69 )
+         code_lines = VALUE #( ( `IF  line_index( ITAB[ PGMID  =  'R3TR'  ] ) <>  0 .` ) ) ) ) )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 73 column = 4 ) )
+       location = VALUE #( object = test_read position = VALUE #( line = 73 column = 4 ) )
        has_pseudo_comment = abap_true )
 
     ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 76 column = 4 ) )
+       location = VALUE #( object = test_read position = VALUE #( line = 76 column = 4 ) )
        has_pseudo_comment = abap_true )
 
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_read position = value #( line = 81 column = 4 ) )
+       location = VALUE #( object = test_read position = VALUE #( line = 81 column = 4 ) )
        has_pseudo_comment = abap_true  )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_loop position = value #( line = 4 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_read position = VALUE #( line = 86 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_loop from = 4 to = 7 )
-         code_lines = value #( ( `DATA(IDX) = LINE_INDEX( ITAB[ pgmid = 'R3TR' object = 'CLAS' ] ).` ) ) ) ) )
+         span = VALUE #( object = test_read from = 86 to = 87 )
+         code_lines = VALUE #( ( `IDX = LINE_INDEX( ITAB[ KEY NAME COMPONENTS OBJ_NAME = 'BLABLA' ] ).` ) ) ) ) )
+
+     ( code = /cc4a/modern_language=>message_codes-line_exists
+       location = VALUE #( object = test_read position = VALUE #( line = 90 column = 4 ) )
+       quickfixes = VALUE #( (
+         quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
+         span = VALUE #( object = test_read from = 90 to = 91 )
+         code_lines = VALUE #( ( `IDX = LINE_INDEX( ITAB_SORTED[ PGMID = 'R3TR' OBJECT = 'CLAS' ] ).` ) ) ) ) )
+
+     ( code = /cc4a/modern_language=>message_codes-line_exists
+       location = VALUE #( object = test_loop position = VALUE #( line = 4 column = 4 ) )
+       quickfixes = VALUE #( (
+         quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
+         span = VALUE #( object = test_loop from = 4 to = 7 )
+         code_lines = VALUE #( ( `DATA(IDX) = LINE_INDEX( ITAB[ pgmid = 'R3TR' object = 'CLAS' ] ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_loop position = value #( line = 9 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_loop position = VALUE #( line = 9 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_loop from = 9 to = 13 )
-         code_lines = value #( ( `IDX = LINE_INDEX( ITAB[ pgmid = 'R3TR' object = 'CLAS' ] ).` )
+         span = VALUE #( object = test_loop from = 9 to = 13 )
+         code_lines = VALUE #( ( `IDX = LINE_INDEX( ITAB[ pgmid = 'R3TR' object = 'CLAS' ] ).` )
                                ( `DATA(EXISTS) = XSDBOOL( LINE_EXISTS( ITAB[ pgmid = 'R3TR' object = 'CLAS' ] ) ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_loop position = value #( line = 21 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_loop position = VALUE #( line = 21 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_loop from = 21 to = 24 )
-         code_lines = value #( ( `EXISTS = xsdbool( line_exists( ITAB[ OBJ_NAME  =  'BLA' ] ) ).` ) ) ) ) )
+         span = VALUE #( object = test_loop from = 21 to = 24 )
+         code_lines = VALUE #( ( `EXISTS = xsdbool( line_exists( ITAB[ OBJ_NAME  =  'BLA' ] ) ).` ) ) ) ) )
 
    ( code = /cc4a/modern_language=>message_codes-line_exists
-       location = value #( object = test_loop position = value #( line = 38 column = 4 ) )
+       location = VALUE #( object = test_loop position = VALUE #( line = 38 column = 4 ) )
        has_pseudo_comment = abap_true
-       quickfixes = value #( (
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
-         span = value #( object = test_loop from = 38 to = 41 )
-         code_lines = value #( ( `EXISTS = xsdbool( line_exists( ITAB[ OBJ_NAME  =  'BLA' ] ) ).` ) ) ) ) )
+         span = VALUE #( object = test_loop from = 38 to = 41 )
+         code_lines = VALUE #( ( `EXISTS = xsdbool( line_exists( ITAB[ OBJ_NAME  =  'BLA' ] ) ).` ) ) ) ) )
 
 
     ( code = /cc4a/modern_language=>message_codes-prefer_new
-       location = value #( object = test_create_object position = value #( line = 3 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_create_object position = VALUE #( line = 3 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-prefer_new
-         span = value #( object = test_create_object from = 2 to = 3 )
-         code_lines = value #( ( `DATA(object1) = NEW /cc4a/test_modern_language( ).` ) ) ) ) )
+         span = VALUE #( object = test_create_object from = 2 to = 3 )
+         code_lines = VALUE #( ( `DATA(object1) = NEW /cc4a/test_modern_language( ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-prefer_new
-       location = value #( object = test_create_object position = value #( line = 5 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_create_object position = VALUE #( line = 5 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-prefer_new
-         span = value #( object = test_create_object from = 5 to = 5 )
-         code_lines = value #( ( `object1 = NEW #( ).` ) ) ) ) )
+         span = VALUE #( object = test_create_object from = 5 to = 5 )
+         code_lines = VALUE #( ( `object1 = NEW #( ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-prefer_new
-       location = value #( object = test_create_object position = value #( line = 9 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_create_object position = VALUE #( line = 9 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-prefer_new
-         span = value #( object = test_create_object from = 7 to = 12 )
-         code_lines = value #( ( `DATA(CLASS_REF) = NEW LCL_TEST(  PARAM1 = 5 PARAM2 = 4 ).` ) ) ) ) )
+         span = VALUE #( object = test_create_object from = 7 to = 12 )
+         code_lines = VALUE #( ( `DATA(CLASS_REF) = NEW LCL_TEST(  PARAM1 = 5 PARAM2 = 4 ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-prefer_new
-       location = value #( object = test_create_object position = value #( line = 16 column = 8 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_create_object position = VALUE #( line = 16 column = 8 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-prefer_new
-         span = value #( object = test_create_object from = 16 to = 18 )
-         code_lines = value #( ( `CLASS_REF1 = NEW #(  PARAM1 = 15 ).` ) ) ) ) )
+         span = VALUE #( object = test_create_object from = 16 to = 18 )
+         code_lines = VALUE #( ( `CLASS_REF1 = NEW #(  PARAM1 = 15 ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-prefer_new
-       location = value #( object = test_create_object position = value #( line = 32 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_create_object position = VALUE #( line = 32 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-prefer_new
-         span = value #( object = test_create_object from = 31 to = 35 )
-         code_lines = value #( ( `DATA(CLASS_REF3) = NEW LCL_TEST3( param1 = 'blabla'  param2 = |{ sy-datum } { sy-uzeit }| ).` ) ) ) ) )
+         span = VALUE #( object = test_create_object from = 31 to = 35 )
+         code_lines = VALUE #( ( `DATA(CLASS_REF3) = NEW LCL_TEST3( param1 = 'blabla'  param2 = |{ sy-datum } { sy-uzeit }| ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-prefer_new
-       location = value #( object = test_create_object position = value #( line = 37 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_create_object position = VALUE #( line = 37 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-prefer_new
-         span = value #( object = test_create_object from = 37 to = 40 )
-         code_lines = value #( ( `CLASS_REF3 = NEW #( param1 = |{ sy-datum } { sy-uzeit }| param2 = 'bla' ).` ) ) ) ) )
+         span = VALUE #( object = test_create_object from = 37 to = 40 )
+         code_lines = VALUE #( ( `CLASS_REF3 = NEW #( param1 = |{ sy-datum } { sy-uzeit }| param2 = 'bla' ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-prefer_new
-       location = value #( object = test_create_object position = value #( line = 42 column = 4 ) )
+       location = VALUE #( object = test_create_object position = VALUE #( line = 42 column = 4 ) )
        has_pseudo_comment = abap_true
-       quickfixes = value #( (
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-prefer_new
-         span = value #( object = test_create_object from = 42 to = 45 )
-         code_lines = value #( ( `CLASS_REF3 = NEW #( param1 = |{ sy-datum } { sy-uzeit }| param2 = 'bla' ).` ) ) ) ) )
+         span = VALUE #( object = test_create_object from = 42 to = 45 )
+         code_lines = VALUE #( ( `CLASS_REF3 = NEW #( param1 = |{ sy-datum } { sy-uzeit }| param2 = 'bla' ).` ) ) ) ) )
 
    ( code = /cc4a/modern_language=>message_codes-prefer_new
-       location = value #( object = test_create_object position = value #( line = 49 column = 4 ) )
+       location = VALUE #( object = test_create_object position = VALUE #( line = 49 column = 4 ) )
        has_pseudo_comment = abap_true
-       quickfixes = value #( (
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-prefer_new
-         span = value #( object = test_create_object from = 49 to = 51 )
-         code_lines = value #( ( `SELFISH = NEW #( val = selfish->my_val ).` ) ) ) ) )
+         span = VALUE #( object = test_create_object from = 49 to = 51 )
+         code_lines = VALUE #( ( `SELFISH = NEW #( val = selfish->my_val ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-call_method
-       location = value #( object = test_call_method position = value #( line = 6 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_call_method position = VALUE #( line = 6 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-call_method
-         span = value #( object = test_call_method from = 6 to = 6 )
-         code_lines = value #( ( `TEST_CREATE_OBJECT( ).` ) ) ) ) )
+         span = VALUE #( object = test_call_method from = 6 to = 6 )
+         code_lines = VALUE #( ( `TEST_CREATE_OBJECT( ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-call_method
-       location = value #( object = test_call_method position = value #( line = 8 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_call_method position = VALUE #( line = 8 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-call_method
-         span = value #( object = test_call_method from = 8 to = 8 )
-         code_lines = value #( ( `TEST_CREATE_OBJECT( ).` ) ) ) ) )
+         span = VALUE #( object = test_call_method from = 8 to = 8 )
+         code_lines = VALUE #( ( `TEST_CREATE_OBJECT( ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-call_method
-       location = value #( object = test_call_method position = value #( line = 10 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_call_method position = VALUE #( line = 10 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-call_method
-         span = value #( object = test_call_method from = 10 to = 14 )
-         code_lines = value #( ( `DATA(RESULT) = CLASS_REF->TEST1( PARAM1 = 15 ).` ) ) ) ) )
+         span = VALUE #( object = test_call_method from = 10 to = 14 )
+         code_lines = VALUE #( ( `DATA(RESULT) = CLASS_REF->TEST1( PARAM1 = 15 ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-call_method
-       location = value #( object = test_call_method position = value #( line = 16 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_call_method position = VALUE #( line = 16 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-call_method
-         span = value #( object = test_call_method from = 16 to = 22 )
-         code_lines = value #( ( `CLASS_REF->TEST2(` )
+         span = VALUE #( object = test_call_method from = 16 to = 22 )
+         code_lines = VALUE #( ( `CLASS_REF->TEST2(` )
                                ( `EXPORTING PARAM1 = 'Blabla'` )
                                ( `IMPORTING PARAM2 = DATA(STRING_RESULT)` )
                                ( `CHANGING PARAM3 = TEST_STRING ).` ) ) ) ) )
 
    ( code = /cc4a/modern_language=>message_codes-call_method
-       location = value #( object = test_call_method position = value #( line = 33 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_call_method position = VALUE #( line = 33 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-call_method
-         span = value #( object = test_call_method from = 33 to = 39 )
-         code_lines = value #( ( `CLASS_REF->TEST4(` )
+         span = VALUE #( object = test_call_method from = 33 to = 39 )
+         code_lines = VALUE #( ( `CLASS_REF->TEST4(` )
                                ( `EXPORTING` )
                                ( `param1 = 1` )
                                ( `param2 = 2` )
@@ -275,152 +289,152 @@ class test implementation.
                                 ( `).` ) ) ) ) )
 
    ( code = /cc4a/modern_language=>message_codes-call_method
-       location = value #( object = test_call_method position = value #( line = 41 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_call_method position = VALUE #( line = 41 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-call_method
-         span = value #( object = test_call_method from = 41 to = 41 )
-         code_lines = value #( ( `class_ref->test1( param1 = 3 ).` ) ) ) ) )
+         span = VALUE #( object = test_call_method from = 41 to = 41 )
+         code_lines = VALUE #( ( `class_ref->test1( param1 = 3 ).` ) ) ) ) )
 
    ( code = /cc4a/modern_language=>message_codes-call_method
-       location = value #( object = test_call_method position = value #( line = 51 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_call_method position = VALUE #( line = 51 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-call_method
-         span = value #( object = test_call_method from = 51 to = 51 )
-         code_lines = value #( ( `    class_ref->test7(` ) ) ) ) )
+         span = VALUE #( object = test_call_method from = 51 to = 51 )
+         code_lines = VALUE #( ( `    class_ref->test7(` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-call_method
-       location = value #( object = test_call_method position = value #( line = 59 column = 4 ) )
+       location = VALUE #( object = test_call_method position = VALUE #( line = 59 column = 4 ) )
        has_pseudo_comment = abap_true
-       quickfixes = value #( (
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-call_method
-         span = value #( object = test_call_method from = 59 to = 59 )
-         code_lines = value #( ( `TEST_CREATE_OBJECT( ).` ) ) ) ) )
+         span = VALUE #( object = test_call_method from = 59 to = 59 )
+         code_lines = VALUE #( ( `TEST_CREATE_OBJECT( ).` ) ) ) ) )
 
 
     ( code = /cc4a/modern_language=>message_codes-method_exporting
-       location = value #( object = test_exporting_receiving position = value #( line = 6 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_exporting_receiving position = VALUE #( line = 6 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-method_exporting
-         span = value #( object = test_call_method from = 6 to = 8 )
-         code_lines = value #( ( `DATA(RESULT) = CLASS_REF->TEST1(` )
+         span = VALUE #( object = test_call_method from = 6 to = 8 )
+         code_lines = VALUE #( ( `DATA(RESULT) = CLASS_REF->TEST1(` )
                                ( `PARAM1 = 15 ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-method_exporting
-       location = value #( object = test_exporting_receiving position = value #( line = 18 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_exporting_receiving position = VALUE #( line = 18 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-method_exporting
-         span = value #( object = test_call_method from = 18 to = 18 )
-         code_lines = value #( ( `result = class_ref->test3( param1 = 15 ).` ) ) ) ) )
+         span = VALUE #( object = test_call_method from = 18 to = 18 )
+         code_lines = VALUE #( ( `result = class_ref->test3( param1 = 15 ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-method_exporting
-       location = value #( object = test_exporting_receiving position = value #( line = 20 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_exporting_receiving position = VALUE #( line = 20 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-method_exporting
-         span = value #( object = test_exporting_receiving from = 20 to = 20 )
-         code_lines = value #( ( `result = class_ref->test1( param1 = class_ref->test3( param1 = 3 ) ).` ) ) ) ) )
+         span = VALUE #( object = test_exporting_receiving from = 20 to = 20 )
+         code_lines = VALUE #( ( `result = class_ref->test1( param1 = class_ref->test3( param1 = 3 ) ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-exporting_receiving
-       location = value #( object = test_exporting_receiving position = value #( line = 23 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_exporting_receiving position = VALUE #( line = 23 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-exporting_receiving
-         span = value #( object = test_exporting_receiving from = 23 to = 26 )
-         code_lines = value #( ( `RESULT =  CLASS_REF->TEST1( PARAM1 = 15 ).` ) ) ) ) )
+         span = VALUE #( object = test_exporting_receiving from = 23 to = 26 )
+         code_lines = VALUE #( ( `RESULT =  CLASS_REF->TEST1( PARAM1 = 15 ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-exporting_receiving
-       location = value #( object = test_exporting_receiving position = value #( line = 29 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_exporting_receiving position = VALUE #( line = 29 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-exporting_receiving
-         span = value #( object = test_exporting_receiving from = 29 to = 29 )
-         code_lines = value #( ( `RESULT =  CLASS_REF->TEST3( PARAM1 = 15 ).` ) ) ) ) )
+         span = VALUE #( object = test_exporting_receiving from = 29 to = 29 )
+         code_lines = VALUE #( ( `RESULT =  CLASS_REF->TEST3( PARAM1 = 15 ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-exporting_receiving
-       location = value #( object = test_exporting_receiving position = value #( line = 33 column = 4 ) )
+       location = VALUE #( object = test_exporting_receiving position = VALUE #( line = 33 column = 4 ) )
        has_pseudo_comment = abap_true
-       quickfixes = value #( (
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-exporting_receiving
-         span = value #( object = test_exporting_receiving from = 33 to = 33 )
-         code_lines = value #( ( `RESULT =  CLASS_REF->TEST1( PARAM1 = CLASS_REF->TEST3( PARAM1 = 3 ) ).` ) ) ) ) )
+         span = VALUE #( object = test_exporting_receiving from = 33 to = 33 )
+         code_lines = VALUE #( ( `RESULT =  CLASS_REF->TEST1( PARAM1 = CLASS_REF->TEST3( PARAM1 = 3 ) ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 4 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 4 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-text_assembly
-         span = value #( object = test_text_assembly from = 4 to = 4 )
-         code_lines = value #( ( `text1 = |ab{ TEXT1 }{ ABAP_TRUE }|.` ) ) ) ) )
+         span = VALUE #( object = test_text_assembly from = 4 to = 4 )
+         code_lines = VALUE #( ( `text1 = |ab{ TEXT1 }{ ABAP_TRUE }|.` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 5 column = 4 ) ) )
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 5 column = 4 ) ) )
 
      ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 7 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 7 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-text_assembly
-         span = value #( object = test_text_assembly from = 7 to = 7 )
-         code_lines = value #( ( `    DATA(bla) = class_ref->test5( param1 = |ab| param2 = |cd| ).` ) ) ) ) )
+         span = VALUE #( object = test_text_assembly from = 7 to = 7 )
+         code_lines = VALUE #( ( `    DATA(bla) = class_ref->test5( param1 = |ab| param2 = |cd| ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 9 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 9 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-text_assembly
-         span = value #( object = test_text_assembly from = 9 to = 9 )
-         code_lines = value #( ( `bla = class_ref->test5( param1 = |ab| param2 = 'xxx' ).` ) ) ) ) )
+         span = VALUE #( object = test_text_assembly from = 9 to = 9 )
+         code_lines = VALUE #( ( `bla = class_ref->test5( param1 = |ab| param2 = 'xxx' ).` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 11 column = 4 ) ) )
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 11 column = 4 ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 13 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 13 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-text_assembly
-         span = value #( object = test_text_assembly from = 13 to = 13 )
-         code_lines = value #( ( `text1 = |{ TEXT1 } \}| ##no_text.` ) ) ) ) )
+         span = VALUE #( object = test_text_assembly from = 13 to = 13 )
+         code_lines = VALUE #( ( `text1 = |{ TEXT1 } \}| ##no_text.` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 15 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 15 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-text_assembly
-         span = value #( object = test_text_assembly from = 15 to = 18 )
-         code_lines = value #( ( `text1 = |[\{"TYPE":"U","TARGET":\{"URL":\{"URL":"www.sap.com/en"\}\}\},\{\}]|.` ) ) ) ) )
+         span = VALUE #( object = test_text_assembly from = 15 to = 18 )
+         code_lines = VALUE #( ( `text1 = |[\{"TYPE":"U","TARGET":\{"URL":\{"URL":"www.sap.com/en"\}\}\},\{\}]|.` ) ) ) ) )
 
    ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 21 column = 4 ) ) )
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 21 column = 4 ) ) )
 
    ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 22 column = 4 ) ) )
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 22 column = 4 ) ) )
 
    ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 23 column = 4 ) ) )
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 23 column = 4 ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 25 column = 4 ) )
-       quickfixes = value #( (
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 25 column = 4 ) )
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-text_assembly
-         span = value #( object = test_text_assembly from = 25 to = 25 )
-         code_lines = value #( ( `text1 =  |\\{ TEXT1 }-|.` ) ) ) ) )
+         span = VALUE #( object = test_text_assembly from = 25 to = 25 )
+         code_lines = VALUE #( ( `text1 =  |\\{ TEXT1 }-|.` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 27 column = 4 ) )
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 27 column = 4 ) )
        has_pseudo_comment = abap_true
-       quickfixes = value #( (
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-text_assembly
-         span = value #( object = test_text_assembly from = 27 to = 27 )
-         code_lines = value #( ( `bla = |ab|.` ) ) ) ) )
+         span = VALUE #( object = test_text_assembly from = 27 to = 27 )
+         code_lines = VALUE #( ( `bla = |ab|.` ) ) ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_text_assembly position = value #( line = 29 column = 4 ) ) )
+       location = VALUE #( object = test_text_assembly position = VALUE #( line = 29 column = 4 ) ) )
 
     ( code = /cc4a/modern_language=>message_codes-text_assembly
-       location = value #( object = test_read position = value #( line = 75 column = 4 ) )
+       location = VALUE #( object = test_read position = VALUE #( line = 75 column = 4 ) )
        has_pseudo_comment = abap_true
-       quickfixes = value #( (
+       quickfixes = VALUE #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-text_assembly
-         span = value #( object = test_read from = 75 to = 75 )
-         code_lines = value #( ( `bla = |Difference in contructor code/line{ SY-TABIX }|.` ) ) ) ) )
+         span = VALUE #( object = test_read from = 75 to = 75 )
+         code_lines = VALUE #( ( `bla = |Difference in contructor code/line{ SY-TABIX }|.` ) ) ) ) )
 
 
     ) ).
 
-  endmethod.
+  ENDMETHOD.
 
 
-endclass.
+ENDCLASS.

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
@@ -26,7 +26,7 @@ CLASS /cc4a/prefer_case_to_elseif DEFINITION
     " Represents one IF / ELSEIF / ELSE branch within an IF block.
     " condition_root holds the left-hand side variable (e.g. TYPE in IF TYPE = 'A').
     " is_else = true for branches that cannot map to a simple WHEN clause:
-    "   ELSE keyword, or IF/ELSEIF conditions joined by AND / OR.
+    "   ELSE keyword, AND conditions, or OR conditions testing different variables.
     TYPES:
       BEGIN OF ty_branch,
         stmt_index     TYPE i,
@@ -53,7 +53,7 @@ CLASS /cc4a/prefer_case_to_elseif DEFINITION
       IMPORTING !procedure    TYPE if_ci_atc_source_code_provider=>ty_procedure
       RETURNING VALUE(result) TYPE if_ci_atc_check=>ty_findings.
 
-    METHODS has_multiple_conditions
+    METHODS has_and_condition
       IMPORTING !statement    TYPE if_ci_atc_source_code_provider=>ty_statement
       RETURNING VALUE(result) TYPE abap_bool.
 
@@ -131,16 +131,21 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
           " Push a new entry for this IF block onto the stack.
           DATA(entry) = VALUE ty_stack_entry( if_stmt_index = idx
                                               if_stmt       = <stmt> ).
-          IF has_multiple_conditions( <stmt> ) = abap_false.
-            " No null check on root: a compilable IF with a simple condition always
-            " has a subject token at position 2 (e.g. TYPE in: IF TYPE = 'A').
+          IF has_and_condition( <stmt> ) = abap_false.
             DATA(root) = get_condition_root( <stmt> ).
-            INSERT VALUE #( stmt_index     = idx
-                            stmt           = <stmt>
-                            condition_root = root
-                            when_value     = get_when_value( <stmt> ) ) INTO TABLE entry-branches.
+            IF root IS NOT INITIAL.
+              INSERT VALUE #( stmt_index     = idx
+                              stmt           = <stmt>
+                              condition_root = root
+                              when_value     = get_when_value( <stmt> ) ) INTO TABLE entry-branches.
+            ELSE.
+              " OR chain with different variables — cannot map to a single WHEN clause.
+              INSERT VALUE #( stmt_index = idx
+                              stmt       = <stmt>
+                              is_else    = abap_true ) INTO TABLE entry-branches.
+            ENDIF.
           ELSE.
-            " AND/OR conditions cannot be expressed as a single WHEN clause.
+            " AND conditions cannot be expressed as a WHEN clause.
             INSERT VALUE #( stmt_index = idx
                             stmt       = <stmt>
                             is_else    = abap_true ) INTO TABLE entry-branches.
@@ -150,15 +155,21 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
         WHEN 'ELSEIF'.
           IF stack IS NOT INITIAL.
             ASSIGN stack[ lines( stack ) ] TO FIELD-SYMBOL(<top>).
-            IF has_multiple_conditions( <stmt> ) = abap_false.
-              " Same guarantee as for IF: compilable simple ELSEIF always has token[2].
+            IF has_and_condition( <stmt> ) = abap_false.
               DATA(elseif_root) = get_condition_root( <stmt> ).
-              INSERT VALUE #( stmt_index     = idx
-                              stmt           = <stmt>
-                              condition_root = elseif_root
-                              when_value     = get_when_value( <stmt> ) ) INTO TABLE <top>-branches.
+              IF elseif_root IS NOT INITIAL.
+                INSERT VALUE #( stmt_index     = idx
+                                stmt           = <stmt>
+                                condition_root = elseif_root
+                                when_value     = get_when_value( <stmt> ) ) INTO TABLE <top>-branches.
+              ELSE.
+                " OR chain with different variables — cannot map to a single WHEN clause.
+                INSERT VALUE #( stmt_index = idx
+                                stmt       = <stmt>
+                                is_else    = abap_true ) INTO TABLE <top>-branches.
+              ENDIF.
             ELSE.
-              " AND/OR conditions cannot be expressed as a single WHEN clause.
+              " AND conditions cannot be expressed as a WHEN clause.
               INSERT VALUE #( stmt_index = idx
                               stmt       = <stmt>
                               is_else    = abap_true ) INTO TABLE <top>-branches.
@@ -193,8 +204,8 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
               " All non-else branches must share the same variable;
               " a mixed chain cannot be cleanly expressed as CASE.
               IF count >= threshold AND count = total_non_else.
-                " Skip the finding entirely when any IF/ELSEIF branch has AND/OR conditions.
-                " Such chains cannot be cleanly expressed as a CASE statement.
+                " Skip the finding when any IF/ELSEIF branch uses AND or a mixed OR
+                " condition — such branches can't map to a WHEN clause.
                 DATA has_complex_branch TYPE abap_bool.
                 LOOP AT popped-branches ASSIGNING FIELD-SYMBOL(<b>) WHERE is_else = abap_true.
                   IF <b>-stmt-keyword = 'IF' OR <b>-stmt-keyword = 'ELSEIF'.
@@ -233,25 +244,34 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
     ENDLOOP.
   ENDMETHOD.
 
-  METHOD has_multiple_conditions.
-    " AND / OR tokens mean the condition spans multiple sub-expressions and
-    " cannot be converted to a single WHEN clause.
-    " TODO: variable is assigned but never used (ABAP cleaner)
-    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<token>)
-        WHERE lexeme = 'AND' OR lexeme = 'OR'.
+  METHOD has_and_condition.
+    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<token>) WHERE lexeme = 'AND'.
       result = abap_true.
       RETURN.
     ENDLOOP.
   ENDMETHOD.
 
   METHOD get_condition_root.
-    " Token layout for a simple condition: [1]=IF/ELSEIF  [2]=<variable>  [3]=operator  [4]=value
+    " Token layout: [1]=IF/ELSEIF  [2]=<variable>  [3]=operator  [4]=value  ([5]=OR [6]=var ...)*
+    " For OR chains all sub-conditions must test the same variable; returns empty if they differ.
     result = VALUE #( statement-tokens[ 2 ]-lexeme OPTIONAL ).
+    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<t>) WHERE lexeme = 'OR'.
+      DATA(next_var) = VALUE #( statement-tokens[ sy-tabix + 1 ]-lexeme OPTIONAL ).
+      IF next_var <> result.
+        CLEAR result.
+        RETURN.
+      ENDIF.
+    ENDLOOP.
   ENDMETHOD.
 
   METHOD get_when_value.
-    " Token layout for a simple condition: [1]=IF/ELSEIF  [2]=<variable>  [3]=operator  [4]=value
+    " Simple:   [1]=kw [2]=var [3]=op [4]=value → 'value'
+    " OR chain: repeat [OR][var][op][value] → 'val1 OR val2 OR ...'
     result = VALUE #( statement-tokens[ 4 ]-lexeme OPTIONAL ).
+    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<t>) WHERE lexeme = 'OR'.
+      DATA(next_val) = VALUE #( statement-tokens[ sy-tabix + 3 ]-lexeme OPTIONAL ).
+      result = |{ result } OR { next_val }|.
+    ENDLOOP.
   ENDMETHOD.
 
   METHOD get_dominant_root.
@@ -299,7 +319,7 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
     " Derive the indentation step from the gap between the IF keyword column and
     " the first statement inside the IF body.
     TRY.
-        DATA(if_col)   = procedure-statements[ if_stmt_index ]-tokens[ 1 ]-position-column. "#EC SCOPE_OF_VAR
+        DATA(if_col)   = procedure-statements[ if_stmt_index ]-tokens[ 1 ]-position-column. "#EC CI_SCOPE_OF_VAR
         DATA(next_col) = procedure-statements[ if_stmt_index + 1 ]-tokens[ 1 ]-position-column.
         IF next_col > if_col.
           indent_step = next_col - if_col.

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
@@ -1,7 +1,6 @@
 CLASS /cc4a/prefer_case_to_elseif DEFINITION
-  PUBLIC
-  FINAL
-  CREATE PUBLIC .
+  PUBLIC FINAL
+  CREATE PUBLIC.
 
   PUBLIC SECTION.
     INTERFACES if_ci_atc_check.
@@ -10,61 +9,90 @@ CLASS /cc4a/prefer_case_to_elseif DEFINITION
       BEGIN OF finding_codes,
         prefer_case TYPE if_ci_atc_check=>ty_finding_code VALUE 'PREF_CASE',
       END OF finding_codes.
+    CONSTANTS:
+      BEGIN OF quickfix_codes,
+        to_case TYPE cl_ci_atc_quickfixes=>ty_quickfix_code VALUE 'PREFTOCASE',
+      END OF quickfix_codes.
 
     METHODS constructor.
 
   PROTECTED SECTION.
+
   PRIVATE SECTION.
     CONSTANTS pseudo_comment TYPE string VALUE 'PREFER_CASE'.
-    CONSTANTS threshold       TYPE i      VALUE 5.
+    " Minimum number of branches sharing the same condition root to trigger a finding.
+    CONSTANTS threshold      TYPE i      VALUE 5.
 
+    " Represents one IF / ELSEIF / ELSE branch within an IF block.
+    " condition_root holds the left-hand side variable (e.g. TYPE in IF TYPE = 'A').
+    " is_else = true for branches that cannot map to a simple WHEN clause:
+    "   ELSE keyword, or IF/ELSEIF conditions joined by AND / OR.
+    TYPES:
+      BEGIN OF ty_branch,
+        stmt_index     TYPE i,
+        stmt           TYPE if_ci_atc_source_code_provider=>ty_statement,
+        condition_root TYPE string,
+        when_value     TYPE string,
+        is_else        TYPE abap_bool,
+      END OF ty_branch.
+    TYPES ty_branches TYPE STANDARD TABLE OF ty_branch WITH EMPTY KEY.
+
+    " One entry per open IF on the nesting stack.
     TYPES:
       BEGIN OF ty_stack_entry,
         if_stmt_index TYPE i,
         if_stmt       TYPE if_ci_atc_source_code_provider=>ty_statement,
+        branches      TYPE ty_branches,
       END OF ty_stack_entry.
-
-    TYPES:
-      BEGIN OF ty_chain,
-        if_stmt_index  TYPE i,
-        if_stmt        TYPE if_ci_atc_source_code_provider=>ty_statement,
-        condition_root TYPE string,
-        count          TYPE i,
-      END OF ty_chain.
 
     DATA code_provider     TYPE REF TO if_ci_atc_source_code_provider.
     DATA assistant_factory TYPE REF TO cl_ci_atc_assistant_factory.
     DATA meta_data         TYPE REF TO /cc4a/if_check_meta_data.
 
     METHODS analyze_procedure
-      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
-      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+      IMPORTING !procedure    TYPE if_ci_atc_source_code_provider=>ty_procedure
+      RETURNING VALUE(result) TYPE if_ci_atc_check=>ty_findings.
 
     METHODS has_multiple_conditions
-      IMPORTING statement     TYPE if_ci_atc_source_code_provider=>ty_statement
+      IMPORTING !statement    TYPE if_ci_atc_source_code_provider=>ty_statement
       RETURNING VALUE(result) TYPE abap_bool.
 
     METHODS get_condition_root
-      IMPORTING statement   TYPE if_ci_atc_source_code_provider=>ty_statement
-      RETURNING VALUE(root) TYPE string.
+      IMPORTING !statement    TYPE if_ci_atc_source_code_provider=>ty_statement
+      RETURNING VALUE(result) TYPE string.
+
+    METHODS get_when_value
+      IMPORTING !statement    TYPE if_ci_atc_source_code_provider=>ty_statement
+      RETURNING VALUE(result) TYPE string.
+
+    METHODS get_dominant_root
+      IMPORTING branches      TYPE ty_branches
+      RETURNING VALUE(result) TYPE string.
+
+    METHODS create_quickfix_code
+      IMPORTING !procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+                if_stmt_index    TYPE i
+                endif_stmt_index TYPE i
+                dominant_root    TYPE string
+                branches         TYPE ty_branches
+      RETURNING VALUE(result)    TYPE if_ci_atc_quickfix=>ty_code.
+
 ENDCLASS.
-
-
 
 CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
 
-
   METHOD constructor.
     meta_data = /cc4a/check_meta_data=>create(
-      VALUE #( checked_types     = /cc4a/check_meta_data=>checked_types-abap_programs
-               description       = 'Prefer CASE to ELSE IF'(des)
-               remote_enablement = /cc4a/check_meta_data=>remote_enablement-unconditional
-               finding_codes     = VALUE #(
-                 ( code           = finding_codes-prefer_case
-                   pseudo_comment = pseudo_comment
-                   text           = 'Prefer CASE to ELSE IF for multiple alternative conditions!'(pce) ) ) ) ).
+        VALUE #( checked_types     = /cc4a/check_meta_data=>checked_types-abap_programs
+                 description       = 'Prefer CASE to ELSE IF'(des)
+                 remote_enablement = /cc4a/check_meta_data=>remote_enablement-unconditional
+                 finding_codes     = VALUE #(
+                     ( code           = finding_codes-prefer_case
+                       pseudo_comment = pseudo_comment
+                       text           = 'Prefer CASE to ELSE IF for multiple alternative conditions!'(pce) ) )
+                 quickfix_codes    = VALUE #( ( code       = quickfix_codes-to_case
+                                                short_text = 'Replace IF/ELSEIF chain with CASE statement'(qtc) ) ) ) ).
   ENDMETHOD.
-
 
   METHOD if_ci_atc_check~run.
     code_provider = data_provider->get_code_provider( ).
@@ -74,28 +102,25 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
     ENDLOOP.
   ENDMETHOD.
 
-
   METHOD if_ci_atc_check~get_meta_data.
     meta_data = me->meta_data.
   ENDMETHOD.
-
 
   METHOD if_ci_atc_check~set_assistant_factory.
     assistant_factory = factory.
   ENDMETHOD.
 
-
   METHOD if_ci_atc_check~set_attributes ##NEEDED.
   ENDMETHOD.
-
 
   METHOD if_ci_atc_check~verify_prerequisites.
   ENDMETHOD.
 
-
   METHOD analyze_procedure.
-    DATA stack  TYPE STANDARD TABLE OF ty_stack_entry WITH EMPTY KEY.
-    DATA chains TYPE STANDARD TABLE OF ty_chain       WITH EMPTY KEY.
+    " Stack tracks open IF blocks to handle nested IFs correctly.
+    " Each entry accumulates the branches of one IF block until ENDIF closes it.
+
+    DATA stack TYPE STANDARD TABLE OF ty_stack_entry WITH EMPTY KEY.
 
     LOOP AT procedure-statements ASSIGNING FIELD-SYMBOL(<stmt>).
       DATA(idx) = sy-tabix.
@@ -103,34 +128,50 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
       CASE <stmt>-keyword.
 
         WHEN 'IF'.
-          INSERT VALUE #( if_stmt_index = idx if_stmt = <stmt> ) INTO TABLE stack.
+          " Push a new entry for this IF block onto the stack.
+          DATA(entry) = VALUE ty_stack_entry( if_stmt_index = idx
+                                              if_stmt       = <stmt> ).
           IF has_multiple_conditions( <stmt> ) = abap_false.
+            " No null check on root: a compilable IF with a simple condition always
+            " has a subject token at position 2 (e.g. TYPE in: IF TYPE = 'A').
             DATA(root) = get_condition_root( <stmt> ).
-            IF root IS NOT INITIAL.
-              INSERT VALUE #( if_stmt_index  = idx
-                              if_stmt        = <stmt>
-                              condition_root = root
-                              count          = 1 ) INTO TABLE chains.
-            ENDIF.
+            INSERT VALUE #( stmt_index     = idx
+                            stmt           = <stmt>
+                            condition_root = root
+                            when_value     = get_when_value( <stmt> ) ) INTO TABLE entry-branches.
+          ELSE.
+            " AND/OR conditions cannot be expressed as a single WHEN clause.
+            INSERT VALUE #( stmt_index = idx
+                            stmt       = <stmt>
+                            is_else    = abap_true ) INTO TABLE entry-branches.
           ENDIF.
+          INSERT entry INTO TABLE stack.
 
         WHEN 'ELSEIF'.
           IF stack IS NOT INITIAL.
-            DATA(top) = stack[ lines( stack ) ].
+            ASSIGN stack[ lines( stack ) ] TO FIELD-SYMBOL(<top>).
             IF has_multiple_conditions( <stmt> ) = abap_false.
+              " Same guarantee as for IF: compilable simple ELSEIF always has token[2].
               DATA(elseif_root) = get_condition_root( <stmt> ).
-              IF elseif_root IS NOT INITIAL.
-                TRY.
-                    chains[ if_stmt_index  = top-if_stmt_index
-                            condition_root = elseif_root ]-count += 1.
-                  CATCH cx_sy_itab_line_not_found.
-                    INSERT VALUE #( if_stmt_index  = top-if_stmt_index
-                                    if_stmt        = top-if_stmt
-                                    condition_root = elseif_root
-                                    count          = 1 ) INTO TABLE chains.
-                ENDTRY.
-              ENDIF.
+              INSERT VALUE #( stmt_index     = idx
+                              stmt           = <stmt>
+                              condition_root = elseif_root
+                              when_value     = get_when_value( <stmt> ) ) INTO TABLE <top>-branches.
+            ELSE.
+              " AND/OR conditions cannot be expressed as a single WHEN clause.
+              INSERT VALUE #( stmt_index = idx
+                              stmt       = <stmt>
+                              is_else    = abap_true ) INTO TABLE <top>-branches.
             ENDIF.
+          ENDIF.
+
+        WHEN 'ELSE'.
+          " ELSE has no condition; its body becomes WHEN OTHERS in the quickfix.
+          IF stack IS NOT INITIAL.
+            ASSIGN stack[ lines( stack ) ] TO FIELD-SYMBOL(<top_else>).
+            INSERT VALUE #( stmt_index = idx
+                            stmt       = <stmt>
+                            is_else    = abap_true ) INTO TABLE <top_else>-branches.
           ENDIF.
 
         WHEN 'ENDIF'.
@@ -138,29 +179,64 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
             DATA(popped) = stack[ lines( stack ) ].
             DELETE stack INDEX lines( stack ).
 
-            LOOP AT chains ASSIGNING FIELD-SYMBOL(<chain>) ##PRIMKEY[IF_STMT_INDEX]
-                WHERE if_stmt_index = popped-if_stmt_index
-                  AND count >= threshold.
-              INSERT VALUE #(
-                code               = finding_codes-prefer_case
-                location           = code_provider->get_statement_location( <chain>-if_stmt )
-                checksum           = code_provider->get_statement_checksum( <chain>-if_stmt )
-                has_pseudo_comment = meta_data->has_valid_pseudo_comment(
-                  statement    = <chain>-if_stmt
-                  finding_code = finding_codes-prefer_case )
-              ) INTO TABLE findings.
-              EXIT.
-            ENDLOOP.
+            " Find the condition root that appears most often across non-else branches.
+            DATA(dom_root) = get_dominant_root( popped-branches ).
+            IF dom_root IS NOT INITIAL.
+              DATA(count) = REDUCE i( INIT n = 0
+                                      FOR b IN popped-branches
+                                      WHERE ( condition_root = dom_root )
+                                      NEXT n = n + 1 ).
+              DATA(total_non_else) = REDUCE i( INIT n = 0
+                                               FOR b IN popped-branches
+                                               WHERE ( is_else = abap_false )
+                                               NEXT n = n + 1 ).
+              " All non-else branches must share the same variable;
+              " a mixed chain cannot be cleanly expressed as CASE.
+              IF count >= threshold AND count = total_non_else.
+                " Skip the finding entirely when any IF/ELSEIF branch has AND/OR conditions.
+                " Such chains cannot be cleanly expressed as a CASE statement.
+                DATA has_complex_branch TYPE abap_bool.
+                LOOP AT popped-branches ASSIGNING FIELD-SYMBOL(<b>) WHERE is_else = abap_true.
+                  IF <b>-stmt-keyword = 'IF' OR <b>-stmt-keyword = 'ELSEIF'.
+                    has_complex_branch = abap_true.
+                    EXIT.
+                  ENDIF.
+                ENDLOOP.
 
-            DELETE chains WHERE if_stmt_index = popped-if_stmt_index.
+                IF has_complex_branch = abap_false.
+                  DATA(available_quickfixes) = assistant_factory->create_quickfixes( ).
+                  available_quickfixes->create_quickfix( quickfix_codes-to_case )->replace(
+                      context = assistant_factory->create_quickfix_context(
+                                    VALUE #( procedure_id = procedure-id
+                                             statements   = VALUE #( from = popped-if_stmt_index
+                                                                     to   = idx ) ) )
+                      code    = create_quickfix_code( procedure        = procedure
+                                                      if_stmt_index    = popped-if_stmt_index
+                                                      endif_stmt_index = idx
+                                                      dominant_root    = dom_root
+                                                      branches         = popped-branches ) ).
+                  INSERT VALUE #(
+                      code               = finding_codes-prefer_case
+                      location           = code_provider->get_statement_location( popped-if_stmt )
+                      checksum           = code_provider->get_statement_checksum( popped-if_stmt )
+                      has_pseudo_comment = meta_data->has_valid_pseudo_comment( statement    = popped-if_stmt
+                                                                                finding_code = finding_codes-prefer_case )
+                      details            = assistant_factory->create_finding_details( )->attach_quickfixes(
+                                               available_quickfixes ) )
+                  INTO TABLE result.
+                ENDIF.
+              ENDIF.
+            ENDIF.
           ENDIF.
 
       ENDCASE.
     ENDLOOP.
   ENDMETHOD.
 
-
   METHOD has_multiple_conditions.
+    " AND / OR tokens mean the condition spans multiple sub-expressions and
+    " cannot be converted to a single WHEN clause.
+    " TODO: variable is assigned but never used (ABAP cleaner)
     LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<token>)
         WHERE lexeme = 'AND' OR lexeme = 'OR'.
       result = abap_true.
@@ -168,13 +244,127 @@ CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
     ENDLOOP.
   ENDMETHOD.
 
-
   METHOD get_condition_root.
-    TRY.
-        root = statement-tokens[ 2 ]-lexeme.
-      CATCH cx_sy_itab_line_not_found.
-    ENDTRY.
+    " Token layout for a simple condition: [1]=IF/ELSEIF  [2]=<variable>  [3]=operator  [4]=value
+    result = VALUE #( statement-tokens[ 2 ]-lexeme OPTIONAL ).
   ENDMETHOD.
 
+  METHOD get_when_value.
+    " Token layout for a simple condition: [1]=IF/ELSEIF  [2]=<variable>  [3]=operator  [4]=value
+    result = VALUE #( statement-tokens[ 4 ]-lexeme OPTIONAL ).
+  ENDMETHOD.
+
+  METHOD get_dominant_root.
+    " Count how many branches share each condition root (left-hand side variable).
+    " Returns the root with the highest count; empty if all branches are is_else.
+    TYPES: BEGIN OF ty_root_count,
+             root  TYPE string,
+             count TYPE i,
+           END OF ty_root_count.
+
+    DATA counts TYPE STANDARD TABLE OF ty_root_count WITH EMPTY KEY.
+
+    LOOP AT branches ASSIGNING FIELD-SYMBOL(<branch>) WHERE is_else = abap_false AND condition_root IS NOT INITIAL.
+      TRY.
+          counts[ root = <branch>-condition_root ]-count += 1.
+        CATCH cx_sy_itab_line_not_found.
+          INSERT VALUE #( root  = <branch>-condition_root
+                          count = 1 ) INTO TABLE counts.
+      ENDTRY.
+    ENDLOOP.
+
+    DATA(max_count) = 0.
+    LOOP AT counts ASSIGNING FIELD-SYMBOL(<cnt>).
+      IF <cnt>-count > max_count.
+        max_count = <cnt>-count.
+        result = <cnt>-root.
+      ENDIF.
+    ENDLOOP.
+  ENDMETHOD.
+
+  METHOD create_quickfix_code.
+    DATA indent_step        TYPE i VALUE 2.
+    DATA br                 TYPE ty_branch.
+    DATA in_dominant_branch TYPE abap_bool.
+    DATA branch_body        TYPE if_ci_atc_quickfix=>ty_code.
+    DATA in_else_branch     TYPE abap_bool.
+    " Accumulates body lines for non-dominant branches; emitted as WHEN OTHERS at
+    " the end because ABAP requires WHEN OTHERS to be the last clause in a CASE.
+    DATA else_body          TYPE if_ci_atc_quickfix=>ty_code.
+    DATA has_else           TYPE abap_bool.
+    DATA flat               TYPE string.
+
+    DATA(analyzer) = /cc4a/abap_analyzer=>create( ).
+
+    " Derive the indentation step from the gap between the IF keyword column and
+    " the first statement inside the IF body.
+    TRY.
+        DATA(if_col)   = procedure-statements[ if_stmt_index ]-tokens[ 1 ]-position-column. "#EC SCOPE_OF_VAR
+        DATA(next_col) = procedure-statements[ if_stmt_index + 1 ]-tokens[ 1 ]-position-column.
+        IF next_col > if_col.
+          indent_step = next_col - if_col.
+        ENDIF.
+      CATCH cx_sy_itab_line_not_found.
+    ENDTRY.
+
+    " The quickfix framework prepends if_col spaces to the first line only.
+    " All subsequent lines need their absolute column written explicitly here.
+    DATA(case_indent) = repeat( val = ` `
+                                occ = if_col ).          " ENDCASE level
+    DATA(when_indent) = repeat( val = ` `
+                                occ = if_col + indent_step ).
+    DATA(body_indent) = repeat( val = ` `
+                                occ = if_col + indent_step * 2 ).
+
+    " First line: framework adds if_col, so no explicit prefix needed here.
+    INSERT |CASE { dominant_root } .| INTO TABLE result.
+
+    LOOP AT procedure-statements ASSIGNING FIELD-SYMBOL(<stmt>) FROM if_stmt_index TO endif_stmt_index.
+      CASE <stmt>-keyword.
+        WHEN 'IF' OR 'ELSEIF'.
+          READ TABLE branches INTO br WITH KEY stmt_index = sy-tabix.
+          IF sy-subrc = 0 AND br-is_else = abap_false AND br-condition_root = dominant_root.
+            " Flush any accumulated body before starting the next WHEN clause.
+            IF in_dominant_branch = abap_true.
+              INSERT LINES OF branch_body INTO TABLE result.
+              CLEAR branch_body.
+            ENDIF.
+            INSERT |{ when_indent }WHEN { br-when_value } .| INTO TABLE result.
+            in_dominant_branch = abap_true.
+          ENDIF.
+
+        WHEN 'ELSE'.
+          IF in_dominant_branch = abap_true.
+            INSERT LINES OF branch_body INTO TABLE result.
+            CLEAR branch_body.
+            in_dominant_branch = abap_false.
+          ENDIF.
+          in_else_branch = abap_true.
+          has_else = abap_true.
+
+        WHEN 'ENDIF'.
+          IF in_dominant_branch = abap_true.
+            INSERT LINES OF branch_body INTO TABLE result.
+            CLEAR branch_body.
+          ENDIF.
+          IF in_else_branch = abap_true.
+            INSERT LINES OF branch_body INTO TABLE else_body.
+            CLEAR branch_body.
+          ENDIF.
+          " Emit WHEN OTHERS last — ABAP syntax requires it to be the final clause.
+          IF has_else = abap_true.
+            INSERT |{ when_indent }WHEN OTHERS .| INTO TABLE result.
+            INSERT LINES OF else_body INTO TABLE result.
+          ENDIF.
+          INSERT |{ case_indent }ENDCASE .| INTO TABLE result.
+
+        WHEN OTHERS.
+          IF in_dominant_branch = abap_true OR in_else_branch = abap_true.
+            flat = |{ body_indent }{ analyzer->flatten_tokens( <stmt>-tokens ) }.|.
+            INSERT flat INTO TABLE branch_body.
+          ENDIF.
+      ENDCASE.
+    ENDLOOP.
+  ENDMETHOD.
 
 ENDCLASS.

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.abap
@@ -1,0 +1,180 @@
+CLASS /cc4a/prefer_case_to_elseif DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+    INTERFACES if_ci_atc_check.
+
+    CONSTANTS:
+      BEGIN OF finding_codes,
+        prefer_case TYPE if_ci_atc_check=>ty_finding_code VALUE 'PREF_CASE',
+      END OF finding_codes.
+
+    METHODS constructor.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    CONSTANTS pseudo_comment TYPE string VALUE 'PREFER_CASE'.
+    CONSTANTS threshold       TYPE i      VALUE 5.
+
+    TYPES:
+      BEGIN OF ty_stack_entry,
+        if_stmt_index TYPE i,
+        if_stmt       TYPE if_ci_atc_source_code_provider=>ty_statement,
+      END OF ty_stack_entry.
+
+    TYPES:
+      BEGIN OF ty_chain,
+        if_stmt_index  TYPE i,
+        if_stmt        TYPE if_ci_atc_source_code_provider=>ty_statement,
+        condition_root TYPE string,
+        count          TYPE i,
+      END OF ty_chain.
+
+    DATA code_provider     TYPE REF TO if_ci_atc_source_code_provider.
+    DATA assistant_factory TYPE REF TO cl_ci_atc_assistant_factory.
+    DATA meta_data         TYPE REF TO /cc4a/if_check_meta_data.
+
+    METHODS analyze_procedure
+      IMPORTING procedure       TYPE if_ci_atc_source_code_provider=>ty_procedure
+      RETURNING VALUE(findings) TYPE if_ci_atc_check=>ty_findings.
+
+    METHODS has_multiple_conditions
+      IMPORTING statement     TYPE if_ci_atc_source_code_provider=>ty_statement
+      RETURNING VALUE(result) TYPE abap_bool.
+
+    METHODS get_condition_root
+      IMPORTING statement   TYPE if_ci_atc_source_code_provider=>ty_statement
+      RETURNING VALUE(root) TYPE string.
+ENDCLASS.
+
+
+
+CLASS /cc4a/prefer_case_to_elseif IMPLEMENTATION.
+
+
+  METHOD constructor.
+    meta_data = /cc4a/check_meta_data=>create(
+      VALUE #( checked_types     = /cc4a/check_meta_data=>checked_types-abap_programs
+               description       = 'Prefer CASE to ELSE IF'(des)
+               remote_enablement = /cc4a/check_meta_data=>remote_enablement-unconditional
+               finding_codes     = VALUE #(
+                 ( code           = finding_codes-prefer_case
+                   pseudo_comment = pseudo_comment
+                   text           = 'Prefer CASE to ELSE IF for multiple alternative conditions!'(pce) ) ) ) ).
+  ENDMETHOD.
+
+
+  METHOD if_ci_atc_check~run.
+    code_provider = data_provider->get_code_provider( ).
+    DATA(procedures) = code_provider->get_procedures( code_provider->object_to_comp_unit( object ) ).
+    LOOP AT procedures->* ASSIGNING FIELD-SYMBOL(<procedure>).
+      INSERT LINES OF analyze_procedure( <procedure> ) INTO TABLE findings.
+    ENDLOOP.
+  ENDMETHOD.
+
+
+  METHOD if_ci_atc_check~get_meta_data.
+    meta_data = me->meta_data.
+  ENDMETHOD.
+
+
+  METHOD if_ci_atc_check~set_assistant_factory.
+    assistant_factory = factory.
+  ENDMETHOD.
+
+
+  METHOD if_ci_atc_check~set_attributes ##NEEDED.
+  ENDMETHOD.
+
+
+  METHOD if_ci_atc_check~verify_prerequisites.
+  ENDMETHOD.
+
+
+  METHOD analyze_procedure.
+    DATA stack  TYPE STANDARD TABLE OF ty_stack_entry WITH EMPTY KEY.
+    DATA chains TYPE STANDARD TABLE OF ty_chain       WITH EMPTY KEY.
+
+    LOOP AT procedure-statements ASSIGNING FIELD-SYMBOL(<stmt>).
+      DATA(idx) = sy-tabix.
+
+      CASE <stmt>-keyword.
+
+        WHEN 'IF'.
+          INSERT VALUE #( if_stmt_index = idx if_stmt = <stmt> ) INTO TABLE stack.
+          IF has_multiple_conditions( <stmt> ) = abap_false.
+            DATA(root) = get_condition_root( <stmt> ).
+            IF root IS NOT INITIAL.
+              INSERT VALUE #( if_stmt_index  = idx
+                              if_stmt        = <stmt>
+                              condition_root = root
+                              count          = 1 ) INTO TABLE chains.
+            ENDIF.
+          ENDIF.
+
+        WHEN 'ELSEIF'.
+          IF stack IS NOT INITIAL.
+            DATA(top) = stack[ lines( stack ) ].
+            IF has_multiple_conditions( <stmt> ) = abap_false.
+              DATA(elseif_root) = get_condition_root( <stmt> ).
+              IF elseif_root IS NOT INITIAL.
+                TRY.
+                    chains[ if_stmt_index  = top-if_stmt_index
+                            condition_root = elseif_root ]-count += 1.
+                  CATCH cx_sy_itab_line_not_found.
+                    INSERT VALUE #( if_stmt_index  = top-if_stmt_index
+                                    if_stmt        = top-if_stmt
+                                    condition_root = elseif_root
+                                    count          = 1 ) INTO TABLE chains.
+                ENDTRY.
+              ENDIF.
+            ENDIF.
+          ENDIF.
+
+        WHEN 'ENDIF'.
+          IF stack IS NOT INITIAL.
+            DATA(popped) = stack[ lines( stack ) ].
+            DELETE stack INDEX lines( stack ).
+
+            LOOP AT chains ASSIGNING FIELD-SYMBOL(<chain>) ##PRIMKEY[IF_STMT_INDEX]
+                WHERE if_stmt_index = popped-if_stmt_index
+                  AND count >= threshold.
+              INSERT VALUE #(
+                code               = finding_codes-prefer_case
+                location           = code_provider->get_statement_location( <chain>-if_stmt )
+                checksum           = code_provider->get_statement_checksum( <chain>-if_stmt )
+                has_pseudo_comment = meta_data->has_valid_pseudo_comment(
+                  statement    = <chain>-if_stmt
+                  finding_code = finding_codes-prefer_case )
+              ) INTO TABLE findings.
+              EXIT.
+            ENDLOOP.
+
+            DELETE chains WHERE if_stmt_index = popped-if_stmt_index.
+          ENDIF.
+
+      ENDCASE.
+    ENDLOOP.
+  ENDMETHOD.
+
+
+  METHOD has_multiple_conditions.
+    LOOP AT statement-tokens ASSIGNING FIELD-SYMBOL(<token>)
+        WHERE lexeme = 'AND' OR lexeme = 'OR'.
+      result = abap_true.
+      RETURN.
+    ENDLOOP.
+  ENDMETHOD.
+
+
+  METHOD get_condition_root.
+    TRY.
+        root = statement-tokens[ 2 ]-lexeme.
+      CATCH cx_sy_itab_line_not_found.
+    ENDTRY.
+  ENDMETHOD.
+
+
+ENDCLASS.

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
@@ -1,0 +1,52 @@
+CLASS test DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+    CONSTANTS test_class            TYPE c LENGTH 30 VALUE '/CC4A/TEST_PREFER_CASE_ELSEIF'.
+    CONSTANTS test_class_no_findings TYPE c LENGTH 30 VALUE '/CC4A/TEST_PREFER_CASE_ELSEIF2'.
+    CONSTANTS:
+      BEGIN OF test_class_methods,
+        with_elseif_chain   TYPE c LENGTH 30 VALUE 'WITH_ELSEIF_CHAIN',
+        with_pseudo_comment TYPE c LENGTH 30 VALUE 'WITH_PSEUDO_COMMENT',
+      END OF test_class_methods.
+
+    METHODS execute_test_class FOR TESTING RAISING cx_static_check.
+    METHODS no_findings        FOR TESTING RAISING cx_static_check.
+ENDCLASS.
+
+CLASS test IMPLEMENTATION.
+  METHOD execute_test_class.
+
+    DATA(with_elseif_chain_finding) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_elseif_chain ) )
+          position = VALUE #( line = 3 column = 4 ) ).
+
+    DATA(with_pseudo_comment_finding) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_pseudo_comment ) )
+          position = VALUE #( line = 3 column = 4 ) ).
+
+    cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
+              check             = NEW /cc4a/prefer_case_to_elseif( )
+              object            = VALUE #( type = 'CLAS' name = test_class )
+              expected_findings = VALUE #( code = /cc4a/prefer_case_to_elseif=>finding_codes-prefer_case
+                                           ( location = with_elseif_chain_finding )
+                                           ( location = with_pseudo_comment_finding ) )
+              asserter_config   = VALUE #( quickfixes = abap_false ) ).
+
+  ENDMETHOD.
+
+  METHOD no_findings.
+
+    cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
+              check             = NEW /cc4a/prefer_case_to_elseif( )
+              object            = VALUE #( type = 'CLAS' name = test_class_no_findings )
+              expected_findings = VALUE #( )
+              asserter_config   = VALUE #( quickfixes = abap_false ) ).
+
+  ENDMETHOD.
+
+ENDCLASS.
+

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
@@ -7,8 +7,11 @@ CLASS test DEFINITION FINAL FOR TESTING
     CONSTANTS test_class_no_findings TYPE c LENGTH 30 VALUE '/CC4A/TEST_PREFER_CASE_ELSEIF2'.
     CONSTANTS:
       BEGIN OF test_class_methods,
-        with_elseif_chain   TYPE c LENGTH 30 VALUE 'WITH_ELSEIF_CHAIN',
-        with_pseudo_comment TYPE c LENGTH 30 VALUE 'WITH_PSEUDO_COMMENT',
+        with_elseif_chain     TYPE c LENGTH 30 VALUE 'WITH_ELSEIF_CHAIN',
+        with_pseudo_comment   TYPE c LENGTH 30 VALUE 'WITH_PSEUDO_COMMENT',
+        with_nested_if        TYPE c LENGTH 30 VALUE 'WITH_NESTED_IF',
+        with_double_nested_if TYPE c LENGTH 30 VALUE 'WITH_DOUBLE_NESTED_IF',
+        with_else_branch      TYPE c LENGTH 30 VALUE 'WITH_ELSE_BRANCH',
       END OF test_class_methods.
 
     METHODS execute_test_class FOR TESTING RAISING cx_static_check.
@@ -28,12 +31,134 @@ CLASS test IMPLEMENTATION.
             VALUE #( class = test_class method = test_class_methods-with_pseudo_comment ) )
           position = VALUE #( line = 3 column = 4 ) ).
 
+    DATA(with_nested_if_finding) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_nested_if ) )
+          position = VALUE #( line = 5 column = 6 ) ).
+
+    DATA(with_double_nested_finding_1) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_double_nested_if ) )
+          position = VALUE #( line = 6 column = 6 ) ).
+
+    DATA(with_double_nested_finding_2) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_double_nested_if ) )
+          position = VALUE #( line = 19 column = 6 ) ).
+
+    DATA(with_else_branch_finding) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_else_branch ) )
+          position = VALUE #( line = 3 column = 4 ) ).
+
     cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
               check             = NEW /cc4a/prefer_case_to_elseif( )
               object            = VALUE #( type = 'CLAS' name = test_class )
               expected_findings = VALUE #( code = /cc4a/prefer_case_to_elseif=>finding_codes-prefer_case
-                                           ( location = with_elseif_chain_finding )
-                                           ( location = with_pseudo_comment_finding ) )
+                                           ( location = with_elseif_chain_finding
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_elseif_chain_finding
+                                               code = VALUE #(
+                                               ( `CASE TYPE .` )
+                                               ( `      WHEN 'A' .` )
+                                               ( `        DATA(RESULT) = 1 .` )
+                                               ( `      WHEN 'B' .` )
+                                               ( `        RESULT = 2 .` )
+                                               ( `      WHEN 'C' .` )
+                                               ( `        RESULT = 3 .` )
+                                               ( `      WHEN 'D' .` )
+                                               ( `        RESULT = 4 .` )
+                                               ( `      WHEN 'E' .` )
+                                               ( `        RESULT = 5 .` )
+                                               ( `    ENDCASE .` ) ) ) ) )
+                                           ( location = with_pseudo_comment_finding
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_pseudo_comment_finding
+                                               code = VALUE #(
+                                               ( `CASE TYPE .` )
+                                               ( `      WHEN 'A' .` )
+                                               ( `        DATA(RESULT) = 1 .` )
+                                               ( `      WHEN 'B' .` )
+                                               ( `        RESULT = 2 .` )
+                                               ( `      WHEN 'C' .` )
+                                               ( `        RESULT = 3 .` )
+                                               ( `      WHEN 'D' .` )
+                                               ( `        RESULT = 4 .` )
+                                               ( `      WHEN 'E' .` )
+                                               ( `        RESULT = 5 .` )
+                                               ( `    ENDCASE .` ) ) ) ) )
+                                           ( location = with_nested_if_finding
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_nested_if_finding
+                                               code = VALUE #(
+                                               ( `CASE SUBTYPE .` )
+                                               ( `        WHEN 'X' .` )
+                                               ( `          DATA(RESULT) = 1 .` )
+                                               ( `        WHEN 'Y' .` )
+                                               ( `          RESULT = 2 .` )
+                                               ( `        WHEN 'Z' .` )
+                                               ( `          RESULT = 3 .` )
+                                               ( `        WHEN 'W' .` )
+                                               ( `          RESULT = 4 .` )
+                                               ( `        WHEN 'V' .` )
+                                               ( `          RESULT = 5 .` )
+                                               ( `      ENDCASE .` ) ) ) ) )
+                                           ( location = with_double_nested_finding_1
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_double_nested_finding_1
+                                               code = VALUE #(
+                                               ( `CASE SUBTYPE1 .` )
+                                               ( `        WHEN 'X' .` )
+                                               ( `          DATA(RESULT) = 1 .` )
+                                               ( `        WHEN 'Y' .` )
+                                               ( `          RESULT = 2 .` )
+                                               ( `        WHEN 'Z' .` )
+                                               ( `          RESULT = 3 .` )
+                                               ( `        WHEN 'W' .` )
+                                               ( `          RESULT = 4 .` )
+                                               ( `        WHEN 'V' .` )
+                                               ( `          RESULT = 5 .` )
+                                               ( `      ENDCASE .` ) ) ) ) )
+                                           ( location = with_double_nested_finding_2
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_double_nested_finding_2
+                                               code = VALUE #(
+                                               ( `CASE SUBTYPE2 .` )
+                                               ( `        WHEN 'P' .` )
+                                               ( `          RESULT = 10 .` )
+                                               ( `        WHEN 'Q' .` )
+                                               ( `          RESULT = 11 .` )
+                                               ( `        WHEN 'R' .` )
+                                               ( `          RESULT = 12 .` )
+                                               ( `        WHEN 'S' .` )
+                                               ( `          RESULT = 13 .` )
+                                               ( `        WHEN 'T' .` )
+                                               ( `          RESULT = 14 .` )
+                                               ( `      ENDCASE .` ) ) ) ) )
+                                           ( location = with_else_branch_finding
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_else_branch_finding
+                                               code = VALUE #(
+                                               ( `CASE TYPE .` )
+                                               ( `      WHEN 'A' .` )
+                                               ( `        DATA(RESULT) = 1 .` )
+                                               ( `      WHEN 'B' .` )
+                                               ( `        RESULT = 2 .` )
+                                               ( `      WHEN 'C' .` )
+                                               ( `        RESULT = 3 .` )
+                                               ( `      WHEN 'D' .` )
+                                               ( `        RESULT = 4 .` )
+                                               ( `      WHEN 'E' .` )
+                                               ( `        RESULT = 5 .` )
+                                               ( `      WHEN OTHERS .` )
+                                               ( `        RESULT = 0 .` )
+                                               ( `    ENDCASE .` ) ) ) ) ) )
               asserter_config   = VALUE #( quickfixes = abap_false ) ).
 
   ENDMETHOD.
@@ -49,4 +174,3 @@ CLASS test IMPLEMENTATION.
   ENDMETHOD.
 
 ENDCLASS.
-

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.testclasses.abap
@@ -7,11 +7,12 @@ CLASS test DEFINITION FINAL FOR TESTING
     CONSTANTS test_class_no_findings TYPE c LENGTH 30 VALUE '/CC4A/TEST_PREFER_CASE_ELSEIF2'.
     CONSTANTS:
       BEGIN OF test_class_methods,
-        with_elseif_chain     TYPE c LENGTH 30 VALUE 'WITH_ELSEIF_CHAIN',
-        with_pseudo_comment   TYPE c LENGTH 30 VALUE 'WITH_PSEUDO_COMMENT',
-        with_nested_if        TYPE c LENGTH 30 VALUE 'WITH_NESTED_IF',
-        with_double_nested_if TYPE c LENGTH 30 VALUE 'WITH_DOUBLE_NESTED_IF',
-        with_else_branch      TYPE c LENGTH 30 VALUE 'WITH_ELSE_BRANCH',
+        with_elseif_chain       TYPE c LENGTH 30 VALUE 'WITH_ELSEIF_CHAIN',
+        with_pseudo_comment     TYPE c LENGTH 30 VALUE 'WITH_PSEUDO_COMMENT',
+        with_nested_if          TYPE c LENGTH 30 VALUE 'WITH_NESTED_IF',
+        with_double_nested_if   TYPE c LENGTH 30 VALUE 'WITH_DOUBLE_NESTED_IF',
+        with_else_branch        TYPE c LENGTH 30 VALUE 'WITH_ELSE_BRANCH',
+        with_or_condition       TYPE c LENGTH 30 VALUE 'WITH_OR_CONDITION',
       END OF test_class_methods.
 
     METHODS execute_test_class FOR TESTING RAISING cx_static_check.
@@ -49,6 +50,11 @@ CLASS test IMPLEMENTATION.
     DATA(with_else_branch_finding) = VALUE if_ci_atc_check=>ty_location(
           object   = cl_ci_atc_unit_driver=>get_method_object(
             VALUE #( class = test_class method = test_class_methods-with_else_branch ) )
+          position = VALUE #( line = 3 column = 4 ) ).
+
+    DATA(with_or_condition_finding) = VALUE if_ci_atc_check=>ty_location(
+          object   = cl_ci_atc_unit_driver=>get_method_object(
+            VALUE #( class = test_class method = test_class_methods-with_or_condition ) )
           position = VALUE #( line = 3 column = 4 ) ).
 
     cl_ci_atc_unit_driver=>create_asserter( )->check_and_assert(
@@ -158,6 +164,23 @@ CLASS test IMPLEMENTATION.
                                                ( `        RESULT = 5 .` )
                                                ( `      WHEN OTHERS .` )
                                                ( `        RESULT = 0 .` )
+                                               ( `    ENDCASE .` ) ) ) ) )
+                                           ( location = with_or_condition_finding
+                                               quickfixes = VALUE #( (
+                                               quickfix_code = /cc4a/prefer_case_to_elseif=>quickfix_codes-to_case
+                                               location = with_or_condition_finding
+                                               code = VALUE #(
+                                               ( `CASE TYPE .` )
+                                               ( `      WHEN 'A' OR 'B' .` )
+                                               ( `        DATA(RESULT) = 1 .` )
+                                               ( `      WHEN 'C' .` )
+                                               ( `        RESULT = 2 .` )
+                                               ( `      WHEN 'D' .` )
+                                               ( `        RESULT = 3 .` )
+                                               ( `      WHEN 'E' .` )
+                                               ( `        RESULT = 4 .` )
+                                               ( `      WHEN 'F' .` )
+                                               ( `        RESULT = 5 .` )
                                                ( `    ENDCASE .` ) ) ) ) ) )
               asserter_config   = VALUE #( quickfixes = abap_false ) ).
 

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.xml
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>/CC4A/PREFER_CASE_TO_ELSEIF</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Prefer CASE to ELSE IF</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/checks/#cc4a#prefer_case_to_elseif.clas.xml
+++ b/src/checks/#cc4a#prefer_case_to_elseif.clas.xml
@@ -12,6 +12,26 @@
     <UNICODE>X</UNICODE>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>DES</KEY>
+     <ENTRY>Prefer CASE to ELSE IF</ENTRY>
+     <LENGTH>44</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>PCE</KEY>
+     <ENTRY>Prefer CASE to ELSE IF for multiple alternative conditions!</ENTRY>
+     <LENGTH>118</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>QTC</KEY>
+     <ENTRY>Replace IF/ELSEIF chain with CASE statement</ENTRY>
+     <LENGTH>86</LENGTH>
+    </item>
+   </TPOOL>
   </asx:values>
  </asx:abap>
 </abapGit>

--- a/src/checks/(cc4a)prefer_case_to_elseif.chko.json
+++ b/src/checks/(cc4a)prefer_case_to_elseif.chko.json
@@ -1,0 +1,10 @@
+{
+  "formatVersion": "1",
+  "header": {
+    "description": "Prefer CASE to ELSE IF",
+    "originalLanguage": "en"
+  },
+  "category": "/CC4A/CODE_PAL",
+  "implementingClass": "/CC4A/PREFER_CASE_TO_ELSEIF",
+  "checkType": "remoteEnabled"
+}

--- a/src/core/(cc4a)code_pal_full.chkv.json
+++ b/src/core/(cc4a)code_pal_full.chkv.json
@@ -77,6 +77,9 @@
     },
     {
       "checkName": "/CC4A/VARIABLE_SCOPE"
+    },
+    {
+      "checkName": "/CC4A/PREFER_CASE_TO_ELSEIF"
     }
   ]
 }

--- a/src/core/(cc4a)code_pal_remote.chkv.json
+++ b/src/core/(cc4a)code_pal_remote.chkv.json
@@ -74,6 +74,9 @@
     },
     {
       "checkName": "/CC4A/VARIABLE_SCOPE"
+    },
+    {
+      "checkName": "/CC4A/PREFER_CASE_TO_ELSEIF"
     }
   ]
 }

--- a/src/test_objects/#cc4a#test_modern_language.clas.abap
+++ b/src/test_objects/#cc4a#test_modern_language.clas.abap
@@ -1,33 +1,33 @@
-class /cc4a/test_modern_language definition
-  public
-  final
-  create public .
+CLASS /cc4a/test_modern_language DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
 
-  public section.
-    methods test_move.
-    methods test_translate.
-    methods test_read.
-    methods test_loop.
-    methods test_create_object.
-    methods test_call_method.
-    methods test_exporting_receiving.
-    methods test_text_assembly.
-  protected section.
-  private section.
-endclass.
-
-
-
-class /cc4a/test_modern_language implementation.
+  PUBLIC SECTION.
+    METHODS test_move.
+    METHODS test_translate.
+    METHODS test_read.
+    METHODS test_loop.
+    METHODS test_create_object.
+    METHODS test_call_method.
+    METHODS test_exporting_receiving.
+    METHODS test_text_assembly.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
 
 
-  method test_move.
-    types:
-      begin of enum number,
+
+CLASS /cc4a/test_modern_language IMPLEMENTATION.
+
+
+  METHOD test_move.
+    TYPES:
+      BEGIN OF ENUM number,
         n0, n1, n2,
-      end of enum number.
+      END OF ENUM number.
 
-    data num type number  ##NEEDED.
+    DATA num TYPE number  ##NEEDED.
 
 *    MOVE EXACT 1 TO num.
 *
@@ -45,318 +45,326 @@ class /cc4a/test_modern_language implementation.
 *    MOVE a TO b ##DUPLICATE_OK.
 *
 *    MOVE a TO b.                                    "#EC DEPRECATED_KEY
-  endmethod.
+  ENDMETHOD.
 
 
-  method test_translate.
-    data(str1) = `This is Really Mixed` ##NEEDED ##NO_TEXT.
-    translate str1 to upper case.
-    translate str1 to lower case.
-    translate str1 to lower case.                   "#EC DEPRECATED_KEY
-  endmethod.
+  METHOD test_translate.
+    DATA(str1) = `This is Really Mixed` ##NEEDED ##NO_TEXT.
+    TRANSLATE str1 TO UPPER CASE.
+    TRANSLATE str1 TO LOWER CASE.
+    TRANSLATE str1 TO LOWER CASE.                   "#EC DEPRECATED_KEY
+  ENDMETHOD.
 
 
-  method test_read.
-    data itab type standard table of /cc4a/db_test1 with non-unique sorted key name components obj_name.
+  METHOD test_read.
+    DATA itab TYPE STANDARD TABLE OF /cc4a/db_test1 WITH NON-UNIQUE SORTED KEY name COMPONENTS obj_name.
 
-    read table itab transporting no fields with key pgmid = 'R3TR' object = 'CLAS' .
-    data(idx) = sy-tabix ##NEEDED.
+    READ TABLE itab TRANSPORTING NO FIELDS WITH KEY pgmid = 'R3TR' object = 'CLAS' .
+    DATA(idx) = sy-tabix ##NEEDED.
 
-    read table itab with key pgmid = 'R3TR' object = 'CLAS' transporting no fields .
-    if sy-subrc = 0.
+    READ TABLE itab WITH KEY pgmid = 'R3TR' object = 'CLAS' TRANSPORTING NO FIELDS .
+    IF sy-subrc = 0.
       idx = sy-tabix.
-      data(exists) = abap_true.
-    endif.
+      DATA(exists) = abap_true.
+    ENDIF.
     "DATA(idx) = line_index( itab[ pgmid = 'R3TR' object = 'CLAS' ] ).
-    read table itab with key pgmid = 'R3TR' object = 'CLAS' binary search transporting no fields . "no finding because of binary search
-    if sy-subrc = 0.
+    READ TABLE itab WITH KEY pgmid = 'R3TR' object = 'CLAS' BINARY SEARCH TRANSPORTING NO FIELDS . "no finding because of binary search
+    IF sy-subrc = 0.
       idx = sy-tabix.
       exists = abap_true.
-    endif.
+    ENDIF.
 
-    read table itab with key name components obj_name = 'BLABLA' transporting no fields.
+    READ TABLE itab WITH KEY name COMPONENTS obj_name = 'BLABLA' TRANSPORTING NO FIELDS.
     idx = sy-tabix.
-    read table itab transporting no fields with key name components obj_name = 'BLABLA'.
-    if sy-subrc eq 0.
+    READ TABLE itab TRANSPORTING NO FIELDS WITH KEY name COMPONENTS obj_name = 'BLABLA'.
+    IF sy-subrc EQ 0.
       exists = abap_true.
       idx = sy-tabix.
-    endif.
+    ENDIF.
     "idx = line_index( itab[ KEY name COMPONENTS obj_name = 'BLABLA' ] ).
-    read table itab transporting no fields with key name components obj_name = 'BLABLA'.
-    if sy-subrc eq 0.
+    READ TABLE itab TRANSPORTING NO FIELDS WITH KEY name COMPONENTS obj_name = 'BLABLA'.
+    IF sy-subrc EQ 0.
       exists = abap_true.
       idx = sy-tabix.
-      data(bla) = 'hallo' ##NO_TEXT.
-    endif.
+      DATA(bla) = 'hallo' ##NO_TEXT.
+    ENDIF.
 
-    read table itab with key pgmid = 'R3TR' transporting no fields.
+    READ TABLE itab WITH KEY pgmid = 'R3TR' TRANSPORTING NO FIELDS.
     idx = sy-tabix.
 
-    read table itab with key pgmid = 'R3TR' transporting no fields.
-    if sy-subrc <> 0 or exists = abap_true ##NEEDED.
-    endif.
+    READ TABLE itab WITH KEY pgmid = 'R3TR' TRANSPORTING NO FIELDS.
+    IF sy-subrc <> 0 OR exists = abap_true ##NEEDED.
+    ENDIF.
 
-    read table itab transporting no fields with key name components obj_name = 'BLUE'.
-    if sy-subrc <> 0.
-      data(blue) = abap_false ##NEEDED.
-    endif.
+    READ TABLE itab TRANSPORTING NO FIELDS WITH KEY name COMPONENTS obj_name = 'BLUE'.
+    IF sy-subrc <> 0.
+      DATA(blue) = abap_false ##NEEDED.
+    ENDIF.
 
-    read table itab transporting no fields with key name components obj_name = 'BLUE'.
-    if sy-subrc <> 0.
+    READ TABLE itab TRANSPORTING NO FIELDS WITH KEY name COMPONENTS obj_name = 'BLUE'.
+    IF sy-subrc <> 0.
       blue = abap_false.
       idx = sy-tabix.
-    endif.
+    ENDIF.
 
-    read table itab transporting no fields
-      with key pgmid = 'R3TR'.
-    if sy-tabix = 0 ##NEEDED.
-    endif.
+    READ TABLE itab TRANSPORTING NO FIELDS
+      WITH KEY pgmid = 'R3TR'.
+    IF sy-tabix = 0 ##NEEDED.
+    ENDIF.
 
-    read table itab transporting no fields
-      with key pgmid = 'R3TR'.
-    if sy-tabix is initial ##NEEDED.
-    endif.
+    READ TABLE itab TRANSPORTING NO FIELDS
+      WITH KEY pgmid = 'R3TR'.
+    IF sy-tabix IS INITIAL ##NEEDED.
+    ENDIF.
 
-    read table itab transporting no fields
-      with key pgmid = 'R3TR'.
-    if sy-tabix is not initial ##NEEDED.
-    endif.
+    READ TABLE itab TRANSPORTING NO FIELDS
+      WITH KEY pgmid = 'R3TR'.
+    IF sy-tabix IS NOT INITIAL ##NEEDED.
+    ENDIF.
 
-    read table itab transporting no fields
-      with key pgmid = 'R3TR'.                        "#EC PREF_LINE_EX
-    if sy-tabix is not initial ##NEEDED.
-    endif.
+    READ TABLE itab TRANSPORTING NO FIELDS
+      WITH KEY pgmid = 'R3TR'.                        "#EC PREF_LINE_EX
+    IF sy-tabix IS NOT INITIAL ##NEEDED.
+    ENDIF.
 
-    data itab_string type table of string.
-    read table itab_string transporting no fields
-      with key table_line = 'blabla' ##NO_TEXT.
+    DATA itab_string TYPE TABLE OF string.
+    READ TABLE itab_string TRANSPORTING NO FIELDS
+      WITH KEY table_line = 'blabla' ##NO_TEXT.
     bla = 'Difference in contructor code/line' && sy-tabix ##NO_TEXT.
-    read table itab_string transporting no fields
-      with key table_line = 'blub' ##NO_TEXT.
+    READ TABLE itab_string TRANSPORTING NO FIELDS
+      WITH KEY table_line = 'blub' ##NO_TEXT.
 *    MESSAGE i011(sci) INTO DATA(lv_dummy) WITH sy-tabix ##NEEDED.
 
-    data(test) = new lcl_test4(  ).
-    read table itab with key pgmid = 'BLUB' transporting no fields.
-    if sy-subrc <> 0.
+    DATA(test) = NEW lcl_test4(  ).
+    READ TABLE itab WITH KEY pgmid = 'BLUB' TRANSPORTING NO FIELDS.
+    IF sy-subrc <> 0.
       test->test( param = abap_false ).
-    endif.
-  endmethod.
+    ENDIF.
+
+    READ TABLE itab WITH TABLE KEY name COMPONENTS obj_name = 'BLABLA' TRANSPORTING NO FIELDS.
+    idx = sy-tabix.
+
+    DATA itab_sorted TYPE SORTED TABLE OF /cc4a/db_test1 WITH UNIQUE KEY pgmid object.
+    READ TABLE itab_sorted WITH TABLE KEY pgmid = 'R3TR' object = 'CLAS' TRANSPORTING NO FIELDS.
+    idx = sy-tabix.
+
+  ENDMETHOD.
 
 
-  method test_loop.
-    data itab type standard table of /cc4a/db_test1.
+  METHOD test_loop.
+    DATA itab TYPE STANDARD TABLE OF /cc4a/db_test1.
 
-    loop at itab transporting no fields where pgmid = 'R3TR' and object = 'CLAS' .
-      data(idx) = sy-tabix ##NEEDED.
-      exit.
-    endloop.
+    LOOP AT itab TRANSPORTING NO FIELDS WHERE pgmid = 'R3TR' AND object = 'CLAS' .
+      DATA(idx) = sy-tabix ##NEEDED.
+      EXIT.
+    ENDLOOP.
 
-    loop at itab  transporting no fields where pgmid = 'R3TR' and object = 'CLAS' .
+    LOOP AT itab  TRANSPORTING NO FIELDS WHERE pgmid = 'R3TR' AND object = 'CLAS' .
       idx = sy-tabix.
-      data(exists) = abap_true ##NEEDED.
-      exit.
-    endloop.
+      DATA(exists) = abap_true ##NEEDED.
+      EXIT.
+    ENDLOOP.
 
-    loop at itab into data(l_entry) where obj_name = 'BLA' ##INTO_OK. "no finding because l_entry is used
+    LOOP AT itab INTO DATA(l_entry) WHERE obj_name = 'BLA' ##INTO_OK. "no finding because l_entry is used
       exists = abap_true.
-      exit.
-    endloop.
+      EXIT.
+    ENDLOOP.
 *    WRITE l_entry-pgmid.
 
-    loop at itab into l_entry where obj_name = 'BLA' ##INTO_OK.
+    LOOP AT itab INTO l_entry WHERE obj_name = 'BLA' ##INTO_OK.
       exists = abap_true.
-      exit.
-    endloop.
+      EXIT.
+    ENDLOOP.
 
 
-    loop at itab transporting no fields where obj_name = 'BLABLA' and pgmid is not initial.
+    LOOP AT itab TRANSPORTING NO FIELDS WHERE obj_name = 'BLABLA' AND pgmid IS NOT INITIAL.
       exists = abap_true.
-      exit.
-    endloop.
+      EXIT.
+    ENDLOOP.
 
-    constants c_where type string value 'blabla' ##NO_TEXT.
-    loop at itab transporting no fields where (c_where).
+    CONSTANTS c_where TYPE string VALUE 'blabla' ##NO_TEXT.
+    LOOP AT itab TRANSPORTING NO FIELDS WHERE (c_where).
       exists = abap_true.
-      exit.
-    endloop.
+      EXIT.
+    ENDLOOP.
 
-    loop at itab transporting no fields where obj_name = 'BLA'. "#EC PREF_LINE_EX
+    LOOP AT itab TRANSPORTING NO FIELDS WHERE obj_name = 'BLA'. "#EC PREF_LINE_EX
       exists = abap_true.
-      exit.
-    endloop.
+      EXIT.
+    ENDLOOP.
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method test_create_object.
-    data object1 type ref to /cc4a/test_modern_language.
-    create object object1 ##DUPLICATE_OK.
+  METHOD test_create_object.
+    DATA object1 TYPE REF TO /cc4a/test_modern_language.
+    CREATE OBJECT object1 ##DUPLICATE_OK.
 
-    create object object1.
+    CREATE OBJECT object1.
 
-    data class_ref type ref to lcl_test.
+    DATA class_ref TYPE REF TO lcl_test.
 
-    create object class_ref
-      exporting
+    CREATE OBJECT class_ref
+      EXPORTING
         param1 = 5
         param2 = 4.
 
-    data class_ref1 type ref to lcl_test1.
-    try.
-        create object class_ref1
-          exporting
-            param1 = 15  ##NUMBER_OK.
-      catch lcx_error ##NO_HANDLER.
-    endtry.
+    DATA class_ref1 TYPE REF TO lcl_test1.
+    TRY.
+        CREATE OBJECT class_ref1
+          EXPORTING
+            param1 = 15 ##NUMBER_OK.
+      CATCH lcx_error ##NO_HANDLER.
+    ENDTRY.
 
-    data class_ref2 type ref to lcl_test2.
-    create object class_ref2
-      exporting
-        param1 = 13  ##NUMBER_OK
-      exceptions
+    DATA class_ref2 TYPE REF TO lcl_test2.
+    CREATE OBJECT class_ref2
+      EXPORTING
+        param1 = 13 ##NUMBER_OK
+      EXCEPTIONS
         error  = 1 ##SUBRC_OK.
-    if sy-subrc <> 0 ##NEEDED.
-    endif.
+    IF sy-subrc <> 0 ##NEEDED.
+    ENDIF.
 
-    data class_ref3 type ref to lcl_test3.
-    create object class_ref3
-      exporting
+    DATA class_ref3 TYPE REF TO lcl_test3.
+    CREATE OBJECT class_ref3
+      EXPORTING
         param1 = 'blabla' ##NO_TEXT
         param2 = |{ sy-datum } { sy-uzeit }|.
 
-    create object class_ref3
-      exporting
+    CREATE OBJECT class_ref3
+      EXPORTING
         param1 = |{ sy-datum } { sy-uzeit }|
         param2 = 'bla' ##DUPLICATE_OK.
 
-    create object class_ref3
-      exporting
+    CREATE OBJECT class_ref3
+      EXPORTING
         param1 = |{ sy-datum } { sy-uzeit }|
-        param2 = 'bla'. "#EC PREF_NEW
+        param2 = 'bla'.                                   "#EC PREF_NEW
 
 
-    data selfish type ref to lcl_test_selfish.
-    create object selfish
-      exporting
+    DATA selfish TYPE REF TO lcl_test_selfish.
+    CREATE OBJECT selfish
+      EXPORTING
         val = selfish->my_val.
-  endmethod.
+  ENDMETHOD.
 
 
-  method test_call_method.
-    data test_string type string.
+  METHOD test_call_method.
+    DATA test_string TYPE string.
 
-    data(class_ref) = new lcl_test( param1 = 5 param2 = 3 ).
+    DATA(class_ref) = NEW lcl_test( param1 = 5 param2 = 3 ).
 
-    call method test_create_object( ).
+    CALL METHOD test_create_object( ).
 
-    call method test_create_object.
+    CALL METHOD test_create_object.
 
-    call method class_ref->test1
-      exporting
+    CALL METHOD class_ref->test1
+      EXPORTING
         param1 = 15 ##NUMBER_OK
-      receiving
-        result = data(result)  ##NEEDED.
+      RECEIVING
+        result = DATA(result) ##NEEDED.
 
-    call method class_ref->test2
-      exporting
+    CALL METHOD class_ref->test2
+      EXPORTING
         param1 = 'Blabla' ##NO_TEXT
-      importing
-        param2 = data(string_result)  ##NEEDED
-      changing
+      IMPORTING
+        param2 = DATA(string_result) ##NEEDED
+      CHANGING
         param3 = test_string.
 
-    call method class_ref->test3 "no finding because of exceptions
-      exporting
+    CALL METHOD class_ref->test3 "no finding because of exceptions
+      EXPORTING
         param1 = 15 ##NUMBER_OK
-      receiving
+      RECEIVING
         result = result
-      exceptions
+      EXCEPTIONS
         error1 = 1
         error2 = 2 ##SUBRC_OK.
 
-    call method class_ref->test4
-      exporting
+    CALL METHOD class_ref->test4
+      EXPORTING
         param1 = 1
         param2 = 2
         param3 = 3
-      importing
+      IMPORTING
         param4 = result.
 
-    call method class_ref->test1( param1 = 3 ).
+    CALL METHOD class_ref->test1( param1 = 3 ).
 
-    call method (test_string).
+    CALL METHOD (test_string).
 
-    data ptab type abap_parmbind_tab.
-    data xtab type abap_excpbind_tab.
-    call method ('class')=>('method')
-      parameter-table ptab
-      exception-table xtab.
+    DATA ptab TYPE abap_parmbind_tab.
+    DATA xtab TYPE abap_excpbind_tab.
+    CALL METHOD ('class')=>('method')
+      PARAMETER-TABLE ptab
+      EXCEPTION-TABLE xtab.
 
-    call method class_ref->test7(
-      exporting
+    CALL METHOD class_ref->test7(
+      EXPORTING
         param1 = 5
-      importing
-        param2 = data(testnumber1)
-      receiving
-        result = data(testnumber2) ) ##NEEDED.
+      IMPORTING
+        param2 = DATA(testnumber1)
+      RECEIVING
+        result = DATA(testnumber2) ) ##NEEDED.
 
-    call method test_create_object. "#EC CALL_METH_USAGE
+    CALL METHOD test_create_object.                "#EC CALL_METH_USAGE
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method test_exporting_receiving.
-    data test_string type string.
+  METHOD test_exporting_receiving.
+    DATA test_string TYPE string.
 
-    data(class_ref) = new lcl_test( param1 = 5 param2 = 3 ).
+    DATA(class_ref) = NEW lcl_test( param1 = 5 param2 = 3 ).
 
-    data(result) = class_ref->test1(
-      exporting
+    DATA(result) = class_ref->test1(
+      EXPORTING
         param1 = 15 ) ##NEEDED ##NUMBER_OK.
 
     class_ref->test2(
-      exporting
+      EXPORTING
         param1 = 'Blabla' ##NO_TEXT
-      importing
-        param2 = data(string_result) ##NEEDED
-      changing
+      IMPORTING
+        param2 = DATA(string_result) ##NEEDED
+      CHANGING
         param3 = test_string )  ##NEEDED.
 
-    result = class_ref->test3( exporting param1 = 15 ) ##NUMBER_OK.
+    result = class_ref->test3( EXPORTING param1 = 15 ) ##NUMBER_OK.
 
-    result = class_ref->test1( exporting param1 = class_ref->test3( exporting param1 = 3 ) ).
+    result = class_ref->test1( EXPORTING param1 = class_ref->test3( EXPORTING param1 = 3 ) ).
 
 *   with receiving
     class_ref->test1(
-      exporting
+      EXPORTING
         param1 = 15  ##NUMBER_OK
-      receiving result = result ).
+      RECEIVING result = result ).
 
 
-    class_ref->test3( exporting param1 = 15 receiving result = result ) ##NUMBER_OK.
+    class_ref->test3( EXPORTING param1 = 15 RECEIVING result = result ) ##NUMBER_OK.
 
-    class_ref->test3( exporting param1 = 15 receiving result = result exceptions error1 = 1 error2 = 2 ) ##SUBRC_OK ##NUMBER_OK.
+    class_ref->test3( EXPORTING param1 = 15 RECEIVING result = result EXCEPTIONS error1 = 1 error2 = 2 ) ##SUBRC_OK ##NUMBER_OK.
 
-    class_ref->test1( exporting param1 = class_ref->test3( exporting param1 = 3 ) receiving result = result ).
+    class_ref->test1( EXPORTING param1 = class_ref->test3( EXPORTING param1 = 3 ) RECEIVING result = result ).
 
     class_ref->test7(                                     "#EC OPTL_EXP
-      exporting
+      EXPORTING
         param1 = 5
-      importing
-        param2 = data(testnumber1) ##NEEDED
-       receiving
-         result = data(testnumber2) ) ##NEEDED.             "#EC RECEIVING_USAGE
+      IMPORTING
+        param2 = DATA(testnumber1) ##NEEDED
+       RECEIVING
+         result = DATA(testnumber2) ) ##NEEDED.    "#EC RECEIVING_USAGE
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method test_text_assembly.
-    data class_ref type ref to lcl_test ##NEEDED.
-    data text1 type string.
+  METHOD test_text_assembly.
+    DATA class_ref TYPE REF TO lcl_test ##NEEDED.
+    DATA text1 TYPE string.
     text1 = 'ab' && text1 && abap_true.
     text1 = class_ref->test5( param1 = 'a' param2 = 'b' ) && 'end'.
 
-    data(bla) = class_ref->test5( param1 = 'a' && 'b' param2 = 'c' && 'd' ).
+    DATA(bla) = class_ref->test5( param1 = 'a' && 'b' param2 = 'c' && 'd' ).
 
     bla = class_ref->test5( param1 = 'a' && 'b' param2 = 'xxx' ).
 
@@ -369,15 +377,15 @@ class /cc4a/test_modern_language implementation.
               ',{}' &&
             ']'.
 
-    data itab type standard table of /cc4a/db_test1.
+    DATA itab TYPE STANDARD TABLE OF /cc4a/db_test1.
     bla = itab[ 1 ]-object && 'a'.
     bla = 'a' && itab[ 1 ]-obj_name.
-    text1 = text1 && cond #( when itab is initial then 'a' else 'b' ).
+    text1 = text1 && COND #( WHEN itab IS INITIAL THEN 'a' ELSE 'b' ).
 
     text1 =  `\` && text1 && `-`.
 
     bla = 'a' && 'b'.                                "#EC TEXT_ASSEMBLY
 
-    text1 = 'abc' && new lcl_test( param1 = 4 param2 = 5 )->test5( param1 = 'bla' param2 = 'blub' ).
-  endmethod.
-endclass.
+    text1 = 'abc' && NEW lcl_test( param1 = 4 param2 = 5 )->test5( param1 = 'bla' param2 = 'blub' ).
+  ENDMETHOD.
+ENDCLASS.

--- a/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
@@ -8,6 +8,9 @@ CLASS /cc4a/test_prefer_case_elseif DEFINITION
   PRIVATE SECTION.
     METHODS with_elseif_chain.
     METHODS with_pseudo_comment.
+    METHODS with_nested_if.
+    METHODS with_double_nested_if.
+    METHODS with_else_branch.
 ENDCLASS.
 
 
@@ -26,6 +29,7 @@ CLASS /cc4a/test_prefer_case_elseif IMPLEMENTATION.
     ELSEIF type = 'E'.
       result = 5.
     ENDIF.
+
   ENDMETHOD.
 
   METHOD with_pseudo_comment.
@@ -41,6 +45,80 @@ CLASS /cc4a/test_prefer_case_elseif IMPLEMENTATION.
     ELSEIF type = 'E'.
       result = 5.
     ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_nested_if.
+    DATA(type) = 'A'.
+    DATA(subtype) = 'X'.
+    IF type = 'A'.
+      IF subtype = 'X'.
+        DATA(result) = 1.
+      ELSEIF subtype = 'Y'.
+        result = 2.
+      ELSEIF subtype = 'Z'.
+        result = 3.
+      ELSEIF subtype = 'W'.
+        result = 4.
+      ELSEIF subtype = 'V'.
+        result = 5.
+      ENDIF.
+
+    ELSEIF type = 'B'.
+      result = 6.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_double_nested_if.
+    DATA(type) = 'A'.
+    DATA(subtype1) = 'X'.
+    DATA(subtype2) = 'P'.
+    IF type = 'A'.
+      IF subtype1 = 'X'.
+        DATA(result) = 1.
+      ELSEIF subtype1 = 'Y'.
+        result = 2.
+      ELSEIF subtype1 = 'Z'.
+        result = 3.
+      ELSEIF subtype1 = 'W'.
+        result = 4.
+      ELSEIF subtype1 = 'V'.
+        result = 5.
+      ENDIF.
+
+    ELSEIF type = 'B'.
+      IF subtype2 = 'P'.
+        result = 10.
+      ELSEIF subtype2 = 'Q'.
+        result = 11.
+      ELSEIF subtype2 = 'R'.
+        result = 12.
+      ELSEIF subtype2 = 'S'.
+        result = 13.
+      ELSEIF subtype2 = 'T'.
+        result = 14.
+      ENDIF.
+
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_else_branch.
+    DATA(type) = 'A'.
+    IF type = 'A'.
+      DATA(result) = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
+    ELSE.
+      result = 0.
+    ENDIF.
+
   ENDMETHOD.
 ENDCLASS.
-

--- a/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
@@ -1,0 +1,46 @@
+CLASS /cc4a/test_prefer_case_elseif DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    METHODS with_elseif_chain.
+    METHODS with_pseudo_comment.
+ENDCLASS.
+
+
+
+CLASS /cc4a/test_prefer_case_elseif IMPLEMENTATION.
+  METHOD with_elseif_chain.
+    DATA(type) = 'A'.
+    IF type = 'A'.
+      DATA(result) = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD with_pseudo_comment.
+    DATA(type) = 'A'.
+    IF type = 'A'.                                     "#EC PREFER_CASE
+      DATA(result) = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.
+

--- a/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif.clas.abap
@@ -11,6 +11,7 @@ CLASS /cc4a/test_prefer_case_elseif DEFINITION
     METHODS with_nested_if.
     METHODS with_double_nested_if.
     METHODS with_else_branch.
+    METHODS with_or_condition.
 ENDCLASS.
 
 
@@ -118,6 +119,22 @@ CLASS /cc4a/test_prefer_case_elseif IMPLEMENTATION.
       result = 5.
     ELSE.
       result = 0.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_or_condition.
+    DATA(type) = 'A'.
+    IF type = 'A' OR type = 'B'.
+      DATA(result) = 1.
+    ELSEIF type = 'C'.
+      result = 2.
+    ELSEIF type = 'D'.
+      result = 3.
+    ELSEIF type = 'E'.
+      result = 4.
+    ELSEIF type = 'F'.
+      result = 5.
     ENDIF.
 
   ENDMETHOD.

--- a/src/test_objects/#cc4a#test_prefer_case_elseif.clas.xml
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>/CC4A/TEST_PREFER_CASE_ELSEIF</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Test class for check Prefer CASE to ELSE IF</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
@@ -1,0 +1,45 @@
+CLASS /cc4a/test_prefer_case_elseif2 DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC .
+
+  PUBLIC SECTION.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    METHODS below_threshold.
+    METHODS mixed_conditions.
+ENDCLASS.
+
+
+
+CLASS /cc4a/test_prefer_case_elseif2 IMPLEMENTATION.
+  METHOD below_threshold.
+    DATA(type) = 'A'.
+    IF type = 'A'.
+      DATA(result) = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD mixed_conditions.
+    DATA(type) = 'A'.
+    DATA(status) = 'X'.
+    IF type = 'A' AND status = 'X'.
+      DATA(result) = 1.
+    ELSEIF type = 'B' AND status = 'Y'.
+      result = 2.
+    ELSEIF type = 'C' AND status = 'Z'.
+      result = 3.
+    ELSEIF type = 'D' AND status = 'W'.
+      result = 4.
+    ELSEIF type = 'E' AND status = 'V'.
+      result = 5.
+    ENDIF.
+  ENDMETHOD.
+ENDCLASS.
+

--- a/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
@@ -8,6 +8,9 @@ CLASS /cc4a/test_prefer_case_elseif2 DEFINITION
   PRIVATE SECTION.
     METHODS below_threshold.
     METHODS mixed_conditions.
+    METHODS with_complex_if_condition.
+    METHODS with_mixed_elseif_chain.
+    METHODS with_nondominant_before_else.
 ENDCLASS.
 
 
@@ -24,6 +27,7 @@ CLASS /cc4a/test_prefer_case_elseif2 IMPLEMENTATION.
     ELSEIF type = 'D'.
       result = 4.
     ENDIF.
+
   ENDMETHOD.
 
   METHOD mixed_conditions.
@@ -40,6 +44,76 @@ CLASS /cc4a/test_prefer_case_elseif2 IMPLEMENTATION.
     ELSEIF type = 'E' AND status = 'V'.
       result = 5.
     ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_complex_if_condition.
+    DATA result TYPE i.
+    DATA(type) = 'A'.
+    DATA(subtype) = 'X'.
+    IF type = 'A' AND subtype = 'X'.
+      result = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
+    ELSEIF type = 'F'.
+      result = 6.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_mixed_elseif_chain.
+    DATA result   TYPE i.
+    DATA result_x TYPE i.
+    DATA result_y TYPE i.
+    DATA result_z TYPE i.
+    DATA(type)    = 'A'.
+    DATA(subtype) = 'X'.
+    IF subtype = 'X'.
+      result_x = 0.
+    ELSEIF subtype = 'Y'.
+      result_y = 1.
+    ELSEIF type = 'C'.
+      result = 2.
+    ELSEIF type = 'D'.
+      result = 3.
+    ELSEIF type = 'E'.
+      result = 4.
+    ELSEIF type = 'F'.
+      result = 5.
+    ELSEIF type = 'G'.
+      result = 6.
+    ELSEIF subtype = 'Z'.
+      result_z = 7.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_nondominant_before_else.
+    DATA result   TYPE i.
+    DATA result_x TYPE i.
+    DATA(type)    = 'A'.
+    DATA(subtype) = 'X'.
+    IF type = 'A'.
+      result = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
+    ELSEIF subtype = 'X'.
+      result_x = 6.
+    ELSE.
+      result = 0.
+    ENDIF.
+
   ENDMETHOD.
 ENDCLASS.
-

--- a/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.abap
@@ -11,6 +11,7 @@ CLASS /cc4a/test_prefer_case_elseif2 DEFINITION
     METHODS with_complex_if_condition.
     METHODS with_mixed_elseif_chain.
     METHODS with_nondominant_before_else.
+    METHODS with_or_mixed_variables.
 ENDCLASS.
 
 
@@ -113,6 +114,23 @@ CLASS /cc4a/test_prefer_case_elseif2 IMPLEMENTATION.
       result_x = 6.
     ELSE.
       result = 0.
+    ENDIF.
+
+  ENDMETHOD.
+
+  METHOD with_or_mixed_variables.
+    DATA(type)   = 'A'.
+    DATA(status) = 'X'.
+    IF type = 'A' OR status = 'X'.
+      DATA(result) = 1.
+    ELSEIF type = 'B'.
+      result = 2.
+    ELSEIF type = 'C'.
+      result = 3.
+    ELSEIF type = 'D'.
+      result = 4.
+    ELSEIF type = 'E'.
+      result = 5.
     ENDIF.
 
   ENDMETHOD.

--- a/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.xml
+++ b/src/test_objects/#cc4a#test_prefer_case_elseif2.clas.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>/CC4A/TEST_PREFER_CASE_ELSEIF2</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Test class for check Prefer CASE to ELSE IF (no findings)</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Fixes #59

## Changes
The "Modern Language" check's `analyze_read` method only detected `WITH KEY`
clauses, silently ignoring `WITH TABLE KEY` statements.

The fix falls back to searching for `WITH TABLE KEY` when `WITH KEY` is not
found and adjusts the key component offset accordingly:
- `WITH TABLE KEY keyname COMPONENTS comp = val` → `itab[ KEY keyname COMPONENTS comp = val ]`
- `WITH TABLE KEY comp1 = val1 comp2 = val2` → `itab[ comp1 = val1 comp2 = val2 ]`

## Tests
Added two test cases to `TEST_MODERN_LANGUAGE`:
- `READ TABLE ... WITH TABLE KEY keyname COMPONENTS` (named key with COMPONENTS)
- `READ TABLE ... WITH TABLE KEY comp1 = val1 comp2 = val2` (sorted table, no COMPONENTS)