### PR TITLE
Modern Language: Add Support for READ TABLE WITH TABLE KEY

### DIFF
--- a/src/checks/#cc4a#modern_language.clas.abap
+++ b/src/checks/#cc4a#modern_language.clas.abap
@@ -312,33 +312,40 @@ class /cc4a/modern_language implementation.
       return.
     endif.
     data(key_idx) = analyzer->find_clause_index(  tokens = statement-tokens clause = 'WITH KEY' ).
+    data(with_table_key) = abap_false.
     if key_idx = 0.
-      return.
-    else.
-
-      data(start_idx) = analyzer->find_clause_index(  tokens = statement-tokens clause = 'COMPONENTS'
-                                                      start_index = key_idx + 1 ).
-      if start_idx = 0. "with key...
-        start_idx = key_idx + 2.
-      else. "with key name components ...
-        start_idx -= 2.
+      key_idx = analyzer->find_clause_index( tokens = statement-tokens clause = 'WITH TABLE KEY' ).
+      if key_idx = 0.
+        return.
       endif.
-      data(keylen) = 0.
-      data(to_idx) =  analyzer->find_clause_index( tokens = statement-tokens clause = 'TRANSPORTING' start_index = start_idx ) - 1.
-      if to_idx <= 0.
-        to_idx = lines( statement-tokens ).
-      endif.
-      if statement-tokens[ key_idx + 2 ]-lexeme = '='.
-        key = 'TABLE_LINE'.
-        append_tokens( exporting tokens = statement-tokens from_idx = key_idx + 2 to_idx = to_idx
-                       changing result = key ).
-      else.
-        append_tokens( exporting tokens = statement-tokens from_idx = start_idx to_idx = to_idx
-                       changing result = key ).
-      endif.
-      keylen = to_idx - start_idx + 1.
-
+      with_table_key = abap_true.
     endif.
+
+    data(start_idx) = analyzer->find_clause_index(  tokens = statement-tokens clause = 'COMPONENTS'
+                                                    start_index = key_idx + 1 ).
+    if start_idx = 0. "with key...
+      if with_table_key = abap_true.
+        start_idx = key_idx + 3.
+      else.
+        start_idx = key_idx + 2.
+      endif.
+    else. "with key name components ...
+      start_idx -= 2.
+    endif.
+    data(keylen) = 0.
+    data(to_idx) =  analyzer->find_clause_index( tokens = statement-tokens clause = 'TRANSPORTING' start_index = start_idx ) - 1.
+    if to_idx <= 0.
+      to_idx = lines( statement-tokens ).
+    endif.
+    if statement-tokens[ key_idx + 2 ]-lexeme = '='.
+      key = 'TABLE_LINE'.
+      append_tokens( exporting tokens = statement-tokens from_idx = key_idx + 2 to_idx = to_idx
+                     changing result = key ).
+    else.
+      append_tokens( exporting tokens = statement-tokens from_idx = start_idx to_idx = to_idx
+                     changing result = key ).
+    endif.
+    keylen = to_idx - start_idx + 1.
     if keylen = 1.
 *     finding without quickfix since obsolete version read table with key val.
       add_finding(

--- a/src/checks/#cc4a#modern_language.clas.testclasses.abap
+++ b/src/checks/#cc4a#modern_language.clas.testclasses.abap
@@ -141,6 +141,20 @@ class test implementation.
        has_pseudo_comment = abap_true  )
 
      ( code = /cc4a/modern_language=>message_codes-line_exists
+       location = value #( object = test_read position = value #( line = 86 column = 4 ) )
+       quickfixes = value #( (
+         quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
+         span = value #( object = test_read from = 86 to = 87 )
+         code_lines = value #( ( `IDX = LINE_INDEX( ITAB[ KEY NAME COMPONENTS OBJ_NAME = 'BLABLA' ] ).` ) ) ) ) )
+
+     ( code = /cc4a/modern_language=>message_codes-line_exists
+       location = value #( object = test_read position = value #( line = 90 column = 4 ) )
+       quickfixes = value #( (
+         quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists
+         span = value #( object = test_read from = 90 to = 91 )
+         code_lines = value #( ( `IDX = LINE_INDEX( ITAB_SORTED[ PGMID = 'R3TR' OBJECT = 'CLAS' ] ).` ) ) ) ) )
+
+     ( code = /cc4a/modern_language=>message_codes-line_exists
        location = value #( object = test_loop position = value #( line = 4 column = 4 ) )
        quickfixes = value #( (
          quickfix_code = /cc4a/modern_language=>quickfix_codes-line_exists

--- a/src/test_objects/#cc4a#test_modern_language.clas.abap
+++ b/src/test_objects/#cc4a#test_modern_language.clas.abap
@@ -140,6 +140,13 @@ class /cc4a/test_modern_language implementation.
     if sy-subrc <> 0.
       test->test( param = abap_false ).
     endif.
+
+    read table itab with table key name components obj_name = 'BLABLA' transporting no fields.
+    idx = sy-tabix.
+
+    data itab_sorted type sorted table of /cc4a/db_test1 with unique key pgmid object.
+    read table itab_sorted with table key pgmid = 'R3TR' object = 'CLAS' transporting no fields.
+    idx = sy-tabix.
   endmethod.
 
 


### PR DESCRIPTION
Fixes #59

## Changes
The "Modern Language" check's `analyze_read` method only detected `WITH KEY`
clauses, silently ignoring `WITH TABLE KEY` statements.

The fix falls back to searching for `WITH TABLE KEY` when `WITH KEY` is not
found and adjusts the key component offset accordingly:
- `WITH TABLE KEY keyname COMPONENTS comp = val` → `itab[ KEY keyname COMPONENTS comp = val ]`
- `WITH TABLE KEY comp1 = val1 comp2 = val2` → `itab[ comp1 = val1 comp2 = val2 ]`

## Tests
Added two test cases to `TEST_MODERN_LANGUAGE`:
- `READ TABLE ... WITH TABLE KEY keyname COMPONENTS` (named key with COMPONENTS)
- `READ TABLE ... WITH TABLE KEY comp1 = val1 comp2 = val2` (sorted table, no COMPONENTS)